### PR TITLE
Add dependency reinitialization hook for tests

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -50,3 +50,15 @@ def test_dummy_env_true_variants() -> None:
         c = TestClient(load_app(value))
         r = c.get("/healthz")
         assert r.status_code == 200
+
+
+def test_health_switch_to_dummy_via_init_dependencies() -> None:
+    app = load_app()
+    from src.orch import server
+
+    server.init_dependencies(use_dummy=True)
+    c = TestClient(app)
+    r = c.get("/healthz")
+    assert r.status_code == 200
+    data = r.json()
+    assert set(data["providers"]) == {"hosted_fast", "frontier_primary", "frontier_backup", "local_7b"}


### PR DESCRIPTION
## Summary
- add an `init_dependencies` helper to rebuild server dependencies with or without dummy providers
- update FastAPI startup to use the helper and keep metrics configuration centralized
- extend the health check tests to cover switching to dummy providers via the new initializer

## Testing
- pytest tests/test_health.py

------
https://chatgpt.com/codex/tasks/task_e_68ee2a798e708321b3d19818408aea62