### PR TITLE
Handle ORCH_USE_DUMMY truthy variants

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic==2.9.2
 pyyaml==6.0.2
 tenacity==9.0.0
 tomli==2.0.1; python_version < '3.11'
+pytest==8.3.3

--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -1,24 +1,56 @@
-import os
 import asyncio
+from collections.abc import Mapping
+import os
 import time
+
 from fastapi import FastAPI, Header, Request
 from fastapi.responses import JSONResponse
-from .router import load_config, RoutePlanner
+
 from .metrics import MetricsLogger
-from .rate_limiter import ProviderGuards
-from .types import ChatRequest, chat_response_from_provider
 from .providers import ProviderRegistry
+from .rate_limiter import ProviderGuards
+from .router import LoadedConfig, RoutePlanner, load_config
+from .types import ChatRequest, chat_response_from_provider
 
 app = FastAPI(title="llm-orch")
 
-CONFIG_DIR = os.environ.get("ORCH_CONFIG_DIR", os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "config"))
-USE_DUMMY = bool(int(os.environ.get("ORCH_USE_DUMMY", "0")))
+CONFIG_DIR = os.environ.get(
+    "ORCH_CONFIG_DIR",
+    os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "config"),
+)
+METRICS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "metrics")
 
-cfg = load_config(CONFIG_DIR, use_dummy=USE_DUMMY)
-providers = ProviderRegistry(cfg.providers)
-guards = ProviderGuards(cfg.providers)
-planner = RoutePlanner(cfg.router, cfg.providers)
-metrics = MetricsLogger(os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "metrics"))
+cfg: LoadedConfig
+providers: ProviderRegistry
+guards: ProviderGuards
+planner: RoutePlanner
+metrics: MetricsLogger
+
+
+def resolve_dummy_flag_from_env(env: Mapping[str, str] | None = None) -> bool:
+    source = env or os.environ
+    raw_value = source.get("ORCH_USE_DUMMY", "0")
+    if raw_value is None:
+        return False
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def init_dependencies(*, use_dummy: bool) -> None:
+    global cfg, providers, guards, planner, metrics
+
+    cfg = load_config(CONFIG_DIR, use_dummy=use_dummy)
+    providers = ProviderRegistry(cfg.providers)
+    guards = ProviderGuards(cfg.providers)
+    planner = RoutePlanner(cfg.router, cfg.providers)
+    metrics = MetricsLogger(METRICS_DIR)
+
+
+@app.on_event("startup")
+async def _startup_init_dependencies() -> None:
+    init_dependencies(use_dummy=resolve_dummy_flag_from_env())
+
+
+init_dependencies(use_dummy=resolve_dummy_flag_from_env())
 
 @app.get("/healthz")
 async def healthz():
@@ -34,13 +66,20 @@ async def chat_completions(req: Request, body: ChatRequest, x_orch_task_kind: st
     usage_prompt = 0
     usage_completion = 0
 
+    payload_messages = [message.model_dump() for message in body.messages]
+
     for provider_name in [route.primary] + route.fallback:
         attempt += 1
         prov = providers.get(provider_name)
         guard = guards.get(provider_name)
         async with guard:
             try:
-                resp = await prov.chat(body.model, body.messages, temperature=body.temperature, max_tokens=body.max_tokens)
+                resp = await prov.chat(
+                    body.model,
+                    payload_messages,
+                    temperature=body.temperature,
+                    max_tokens=body.max_tokens,
+                )
                 latency = int((time.perf_counter() - start) * 1000)
                 usage_prompt = resp.usage_prompt_tokens or 0
                 usage_completion = resp.usage_completion_tokens or 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_STR = str(ROOT)
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,6 +2,7 @@ import os
 os.environ.setdefault("ORCH_CONFIG_DIR", "config")
 from fastapi.testclient import TestClient
 from src.orch.server import app
+from src.orch import server as server_mod
 
 def test_health():
     c = TestClient(app)
@@ -12,6 +13,7 @@ def test_health():
 def test_chat_dummy():
     # use dummy providers file for offline test
     os.environ["ORCH_USE_DUMMY"] = "1"
+    server_mod.init_dependencies(use_dummy=True)
     c = TestClient(app)
     r = c.post("/v1/chat/completions", json={
         "model":"dummy",
@@ -21,3 +23,39 @@ def test_chat_dummy():
     data = r.json()
     assert data["object"] == "chat.completion"
     assert data["choices"][0]["message"]["role"] == "assistant"
+
+
+def test_reinitialize_dependencies_for_dummy_provider():
+    os.environ["ORCH_USE_DUMMY"] = "0"
+    server_mod.init_dependencies(use_dummy=False)
+    os.environ["ORCH_USE_DUMMY"] = "1"
+    server_mod.init_dependencies(use_dummy=True)
+    c = TestClient(app)
+    r = c.post(
+        "/v1/chat/completions",
+        json={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "ping"}],
+        },
+    )
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["choices"][0]["message"]["content"].startswith("dummy:")
+
+
+def test_dummy_env_true_variants():
+    for value in ("1", "true", "True", "TRUE"):
+        os.environ["ORCH_USE_DUMMY"] = value
+        server_mod.init_dependencies(
+            use_dummy=server_mod.resolve_dummy_flag_from_env()
+        )
+        c = TestClient(app)
+        r = c.post(
+            "/v1/chat/completions",
+            json={
+                "model": "dummy",
+                "messages": [{"role": "user", "content": value}],
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["choices"][0]["message"]["content"].startswith("dummy:")


### PR DESCRIPTION
## Summary
- add a helper to resolve the ORCH_USE_DUMMY flag so various truthy strings work without raising
- extend the health tests to cover several truthy environment variants for dummy providers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ee24fde7888321a39cdfc7c2e22388