### PR TITLE
Add pytest dependency for test execution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.6
 httpx==0.27.2
 pydantic==2.9.2
+pytest>=8.0.0,<9.0.0
 pyyaml==6.0.2
 tenacity==9.0.0
 tomli==2.0.1; python_version < '3.11'


### PR DESCRIPTION
## Summary
- add pytest to the Python requirements so the project test suite can run in created virtual environments

## Testing
- python -m pip install -r requirements.txt
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ee2bb4d7d08321b1fbb5a75035546e