### PR TITLE
Fix reflection workflow when test logs artifact is missing

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           name: test-logs
           path: logs
+          if-no-artifact-found: ignore
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/tests/test_workflow_reflection.py
+++ b/tests/test_workflow_reflection.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def test_reflection_download_artifact_allows_missing() -> None:
+    workflow_path = Path(".github/workflows/reflection.yml")
+    content = yaml.safe_load(workflow_path.read_text())
+    steps = content["jobs"]["reflect"]["steps"]
+    download_step = next(
+        step for step in steps if step.get("uses") == "actions/download-artifact@v4"
+    )
+    assert download_step["with"]["if-no-artifact-found"] == "ignore"


### PR DESCRIPTION
## Summary
- allow the reflection workflow to continue when the test-logs artifact is not available by ignoring the missing artifact
- add a regression test that asserts the workflow keeps the ignore configuration

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ee2d957e4c8321baed06e9491b5ad0