### PR TITLE
Add config validation test and improve error context

### DIFF
--- a/src/orch/router.py
+++ b/src/orch/router.py
@@ -74,11 +74,11 @@ def load_config(config_dir: str, use_dummy: bool=False) -> LoadedConfig:
         routes=routes_cfg
     )
     for route_name, route in routes_cfg.items():
-        referenced = [route.primary, *route.fallback]
-        for provider_name in referenced:
+        referenced = [(route.primary, "primary"), *[(name, "fallback") for name in route.fallback]]
+        for provider_name, origin in referenced:
             if provider_name not in providers:
                 raise ValueError(
-                    f"Route '{route_name}' references undefined provider '{provider_name}'"
+                    f"Route '{route_name}' references undefined provider '{provider_name}' in {origin}"
                 )
     return LoadedConfig(providers=providers, router=router)
 

--- a/tests/test_router_config.py
+++ b/tests/test_router_config.py
@@ -1,0 +1,29 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_router_module():
+    project_root = Path(__file__).resolve().parents[1]
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+    importlib.invalidate_caches()
+    return importlib.import_module("src.orch.router")
+
+
+def test_load_config_raises_when_fallback_provider_missing(tmp_path):
+    load_config = _load_router_module().load_config
+    config_dir = tmp_path
+    (config_dir / "providers.toml").write_text(
+        """[existing]\nbase_url = \"https://example.com\"\nmodel = \"gpt\"\n""",
+        encoding="utf-8",
+    )
+    (config_dir / "router.yaml").write_text(
+        """routes:\n  DEFAULT:\n    primary: existing\n    fallback:\n      - missing\n""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="fallback"):
+        load_config(str(config_dir))


### PR DESCRIPTION
## Summary
- add a regression test ensuring load_config rejects routes referencing missing providers
- clarify the provider validation error message to identify the primary or fallback origin

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee48f64bc483218ee6eaf8580a7306