### PR TITLE
Add regression for missing default route

### DIFF
--- a/src/orch/router.py
+++ b/src/orch/router.py
@@ -94,4 +94,8 @@ class RoutePlanner:
         default_route = self.cfg.routes.get("DEFAULT")
         if default_route is not None:
             return default_route
-        raise ValueError(f"no route configured for task '{task}' and no DEFAULT route")
+        available = ", ".join(sorted(self.cfg.routes.keys())) or "<none>"
+        raise ValueError(
+            "no route configured for task "
+            f"'{task}' and no DEFAULT route; available routes: {available}"
+        )

--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -52,7 +52,7 @@ async def chat_completions(req: Request, body: ChatRequest, x_orch_task_kind: st
     try:
         route = planner.plan(task)
     except ValueError as exc:
-        detail = str(exc)
+        detail = str(exc) or "routing unavailable"
         await metrics.write({
             "ts": time.time(),
             "task": task,

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -1,0 +1,76 @@
+import importlib
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def load_app(dummy_env: str | None = None) -> FastAPI:
+    module_name = "src.orch.server"
+    sys.modules.pop(module_name, None)
+    sys.modules.pop("src.orch", None)
+    if dummy_env is None:
+        os.environ.pop("ORCH_USE_DUMMY", None)
+    else:
+        os.environ["ORCH_USE_DUMMY"] = dummy_env
+    project_root = Path(__file__).resolve().parents[1]
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+    importlib.invalidate_caches()
+    module = importlib.import_module(module_name)
+    return module.app
+
+
+def _write_dummy_provider_config(base: Path) -> None:
+    (base / "providers.dummy.toml").write_text(
+        textwrap.dedent(
+            """
+            [dummy]
+            type = "dummy"
+            model = "dummy"
+            base_url = ""
+            rpm = 60
+            concurrency = 1
+            """
+        ).strip()
+    )
+
+
+def _write_router_config_without_default(base: Path) -> None:
+    (base / "router.yaml").write_text(
+        textwrap.dedent(
+            """
+            defaults:
+              temperature: 0.2
+              max_tokens: 64
+              task_header: "x-orch-task-kind"
+            routes:
+              PLAN:
+                primary: dummy
+            """
+        ).strip()
+    )
+
+
+def test_chat_missing_default_includes_available_routes(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ORCH_CONFIG_DIR", str(tmp_path))
+    _write_dummy_provider_config(tmp_path)
+    _write_router_config_without_default(tmp_path)
+
+    client = TestClient(load_app("1"))
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "no route configured" in detail
+    assert "available routes" in detail
+    assert "PLAN" in detail


### PR DESCRIPTION
## Summary
- add a regression test covering chat completions requests when router config lacks a DEFAULT route
- include available route names in the routing error raised by RoutePlanner
- keep chat completion failures informative even if the planner error lacks a message

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee48f620608321bc5fcbd81f6f6d33