### PR TITLE
Fix CODEOWNERS approval gate action

### DIFF
--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -7,8 +7,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check CODEOWNERS approval
-        uses: mheap/github-action-required-reviewers@v2
-        with: { reviewers: 'CODEOWNERS', failOnMissing: true }
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    reviewDecision
+                  }
+                }
+              }
+            `;
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: context.issue.number,
+            });
+            const decision = result.repository.pullRequest?.reviewDecision;
+            if (decision !== 'APPROVED') {
+              core.setFailed(`Pull request review decision is ${decision ?? 'UNKNOWN'}`);
+            }
       - name: Block auto-merge
         run: |
           echo "Auto merge is disabled by policy"


### PR DESCRIPTION
## Summary
- replace the removed mheap/github-action-required-reviewers action with actions/github-script
- use the pull request reviewDecision to fail when CODEOWNERS approval is still required

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ee4b0a22308321b459e835b744ea68