### PR TITLE
Add router default task header value support

### DIFF
--- a/src/orch/router.py
+++ b/src/orch/router.py
@@ -55,6 +55,7 @@ def load_config(config_dir: str, use_dummy: bool=False) -> LoadedConfig:
     with open(os.path.join(config_dir, "router.yaml"), "r", encoding="utf-8") as f:
         rdata = yaml.safe_load(f)
     defs = rdata.get("defaults", {})
+    task_header_value = defs.get("task_header_value")
     routes_cfg = {}
     for k, v in rdata.get("routes", {}).items():
         fallback_raw = v.get("fallback")
@@ -70,7 +71,7 @@ def load_config(config_dir: str, use_dummy: bool=False) -> LoadedConfig:
             temperature=float(defs.get("temperature", 0.2)),
             max_tokens=int(defs.get("max_tokens", 2048)),
             task_header=str(defs.get("task_header", "x-orch-task-kind")),
-            task_header_value=None
+            task_header_value=str(task_header_value) if task_header_value is not None else None
         ),
         routes=routes_cfg
     )

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -47,6 +47,7 @@ defaults:
   temperature: 0.2
   max_tokens: 64
   task_header: "x-orch-task-kind"
+  task_header_value: "PLAN"
 routes:
   PLAN:
     primary: dummy
@@ -69,3 +70,16 @@ def test_chat_missing_route_and_default_returns_400(route_test_config: Path) -> 
     assert response.json()["detail"] == (
         "no route configured for task 'IDEATE' and no DEFAULT route defined in router configuration."
     )
+
+
+def test_chat_missing_header_uses_default_task_value(route_test_config: Path) -> None:
+    client = TestClient(load_app("1"))
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "dummy:hi"


### PR DESCRIPTION
## Summary
- propagate the optional defaults.task_header_value into RouterDefaults when loading the router configuration
- extend the server routing test fixture and add coverage for routing when the header is omitted

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee4fb4e35483219cb90eee5adf01da