### PR TITLE
Ensure pr gate workflow requests review decision preview

### DIFF
--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -23,6 +23,9 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               number: context.issue.number,
+              headers: {
+                accept: 'application/vnd.github.merge-info-preview+json',
+              },
             });
             const decision = result.repository.pullRequest?.reviewDecision;
             if (decision !== 'APPROVED') {

--- a/tests/test_pr_gate_workflow.py
+++ b/tests/test_pr_gate_workflow.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_pr_gate_uses_merge_info_preview_header() -> None:
+    workflow_path = Path('.github/workflows/pr_gate.yml')
+    workflow = yaml.safe_load(workflow_path.read_text())
+    steps = workflow['jobs']['gate']['steps']
+    check_step = next(step for step in steps if step.get('name') == 'Check CODEOWNERS approval')
+    script = check_step['with']['script']
+    assert 'application/vnd.github.merge-info-preview+json' in script


### PR DESCRIPTION
## Summary
- add the merge-info preview accept header to the pr-gate workflow's GraphQL query so reviewDecision is populated
- add a regression test that enforces the presence of the preview header in the workflow script

## Testing
- pytest tests/test_pr_gate_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68ee518770ec8321abf32d6d61fcd764