### PR TITLE
Add async rate limiter test and fix token acquisition loop

### DIFF
--- a/src/orch/rate_limiter.py
+++ b/src/orch/rate_limiter.py
@@ -28,8 +28,10 @@ class Guard:
     self.sem = asyncio.Semaphore(concurrency)
 
   async def __aenter__(self):
-    delay = self.bucket.try_take()
-    if delay > 0:
+    while True:
+      delay = self.bucket.try_take()
+      if delay <= 0:
+        break
       await asyncio.sleep(delay)
     await self.sem.acquire()
     return self

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+  sys.path.insert(0, str(PROJECT_ROOT))
+
+import src.orch.rate_limiter as rate_limiter
+from src.orch.rate_limiter import Guard
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+  return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_guard_respects_rpm_after_wait(monkeypatch, anyio_backend: str):
+  fake_time = 0.0
+  sleeps: list[float] = []
+
+  async def fake_sleep(delay: float) -> None:
+    sleeps.append(delay)
+    nonlocal fake_time
+    fake_time += delay
+
+  def fake_time_func() -> float:
+    return fake_time
+
+  monkeypatch.setattr(rate_limiter.time, "time", fake_time_func)
+  monkeypatch.setattr(rate_limiter.asyncio, "sleep", fake_sleep)
+
+  guard = Guard(rpm=2, concurrency=1)
+
+  async def acquire_once() -> None:
+    async with guard:
+      pass
+
+  await acquire_once()
+  await acquire_once()
+  await acquire_once()
+  assert sleeps == [60.0]
+
+  sleeps.clear()
+  await acquire_once()
+  assert sleeps == []
+
+  await acquire_once()
+  assert sleeps == [60.0]


### PR DESCRIPTION
## Summary
- add an async regression test to ensure Guard waits for the token bucket before proceeding
- update Guard.__aenter__ to retry token acquisition after sleeping so tokens are actually consumed

## Testing
- pytest tests/test_rate_limiter.py


------
https://chatgpt.com/codex/tasks/task_e_68ee6d4f75c8832190e799189d103ed8