### PR TITLE
Fix OpenAI compat chat URL assembly for v1 base URLs

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -14,8 +14,12 @@ class BaseProvider:
 
 class OpenAICompatProvider(BaseProvider):
     async def chat(self, model: str, messages: List[dict[str, str]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
-        base = self.defn.base_url.rstrip('/')
-        url = f"{base}/chat/completions" if "/openai/" in base else f"{base}/v1/chat/completions"
+        base = self.defn.base_url.rstrip("/")
+        if "/openai/" in base:
+            url = f"{base}/chat/completions"
+        else:
+            suffix = "/chat/completions" if base.endswith("/v1") else "/v1/chat/completions"
+            url = f"{base}{suffix}"
         key = os.environ.get(self.defn.auth_env or "", "")
         headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
         payload = {"model": self.defn.model or model, "messages": messages, "temperature": temperature, "max_tokens": max_tokens, "stream": False}

--- a/tests/test_providers_openai_compat.py
+++ b/tests/test_providers_openai_compat.py
@@ -1,0 +1,70 @@
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.orch.providers import OpenAICompatProvider
+from src.orch.router import ProviderDef
+
+
+def test_openai_compat_appends_single_v1_segment(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider_def = ProviderDef(
+        name="openai",
+        type="openai",
+        base_url="https://api.openai.com/v1",
+        model="gpt-4o",
+        auth_env="OPENAI_API_KEY",
+        rpm=60,
+        concurrency=1,
+    )
+    provider = OpenAICompatProvider(provider_def)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+
+    captured: dict[str, Any] = {}
+
+    class DummyAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "DummyAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def post(self, url: str, headers: dict[str, str], json: dict[str, Any]) -> httpx.Response:
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["json"] = json
+            request = httpx.Request("POST", url, headers=headers)
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "model": "gpt-4o",
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 2},
+                },
+                request=request,
+            )
+
+    async def run_chat() -> None:
+        monkeypatch.setattr(httpx, "AsyncClient", DummyAsyncClient)
+        response = await provider.chat(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "ping"}],
+        )
+
+        assert captured["url"] == "https://api.openai.com/v1/chat/completions"
+        request_json = cast(dict[str, Any], captured["json"])
+        assert request_json["stream"] is False
+        assert response.content == "ok"
+
+    asyncio.run(run_chat())


### PR DESCRIPTION
## Summary
- add a regression test covering OpenAICompatProvider chat URL construction for base URLs ending with /v1
- adjust OpenAICompatProvider to avoid duplicating the /v1 segment when assembling the chat completions URL

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee874635bc83219f4b094011ee7f2b