### PR TITLE
Ensure usage metrics exist for failed chat requests

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -70,6 +70,8 @@ async def chat_completions(req: Request, body: ChatRequest):
             "ok": False,
             "status": 400,
             "error": detail,
+            "usage_prompt": 0,
+            "usage_completion": 0,
             "retries": 0,
         })
         raise HTTPException(status_code=400, detail=detail)
@@ -115,6 +117,8 @@ async def chat_completions(req: Request, body: ChatRequest):
                     "ok": False,
                     "status": 0,
                     "error": last_err,
+                    "usage_prompt": 0,
+                    "usage_completion": 0,
                     "retries": attempt - 1,
                 })
                 await asyncio.sleep(min(0.25 * attempt, 2.0))  # simple backoff

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -303,3 +303,62 @@ def test_chat_metrics_provider_error_includes_req_id(
 
     assert response.status_code == 502
     assert_single_req_id(records)
+
+
+def test_chat_metrics_routing_error_usage_defaults_to_zero(
+    route_test_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = load_app("1")
+    server_module = sys.modules["src.orch.server"]
+    records = capture_metric_records(server_module, monkeypatch)
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"x-orch-task-kind": "UNKNOWN"},
+        json={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert response.status_code == 400
+    assert len(records) == 1
+    record = records[0]
+    assert record["usage_prompt"] == 0
+    assert record["usage_completion"] == 0
+
+
+def test_chat_metrics_provider_error_usage_defaults_to_zero(
+    route_test_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = load_app("1")
+    server_module = sys.modules["src.orch.server"]
+    records = capture_metric_records(server_module, monkeypatch)
+
+    async def no_sleep(_: float) -> None:
+        return None
+
+    class BoomProvider:
+        model = "dummy"
+
+        async def chat(self, *args: object, **kwargs: object) -> object:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(server_module.asyncio, "sleep", no_sleep)
+    monkeypatch.setitem(server_module.providers.providers, "dummy", BoomProvider())
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert response.status_code == 502
+    assert len(records) == 1
+    record = records[0]
+    assert record["usage_prompt"] == 0
+    assert record["usage_completion"] == 0


### PR DESCRIPTION
## Summary
- add regression tests that verify routing and provider failures emit zeroed usage metrics
- populate usage_prompt and usage_completion for failed metrics writes in chat endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eee210cee88321babaa384380ba024