### PR TITLE
Handle unknown review decision in PR gate

### DIFF
--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -29,7 +29,10 @@ jobs:
               },
             });
             const decisionRaw = result.repository.pullRequest?.reviewDecision;
-            const decision = decisionRaw ?? 'REVIEW_REQUIRED';
+            const decision =
+              decisionRaw === 'UNKNOWN' || decisionRaw === null || decisionRaw === undefined
+                ? 'REVIEW_REQUIRED'
+                : decisionRaw;
             if (decision !== 'APPROVED') {
               core.setFailed(`Pull request review decision is ${decision}`);
             }

--- a/tests/test_pr_gate_workflow.py
+++ b/tests/test_pr_gate_workflow.py
@@ -12,11 +12,14 @@ def test_pr_gate_uses_merge_info_preview_header() -> None:
     assert 'application/vnd.github.merge-info-preview+json' in script
 
 
-def test_pr_gate_defaults_unknown_decision_to_review_required() -> None:
+def test_pr_gate_normalizes_unknown_decision_to_review_required() -> None:
     workflow_path = Path('.github/workflows/pr_gate.yml')
     workflow = yaml.safe_load(workflow_path.read_text())
     steps = workflow['jobs']['gate']['steps']
     check_step = next(step for step in steps if step.get('name') == 'Check CODEOWNERS approval')
     script = check_step['with']['script']
     normalized_script = script.replace(' ', '').replace('\n', '')
-    assert "??'REVIEW_REQUIRED'" in normalized_script
+    assert (
+        "decisionRaw==='UNKNOWN'||decisionRaw===null||decisionRaw===undefined?'REVIEW_REQUIRED'"
+        in normalized_script
+    )


### PR DESCRIPTION
## Summary
- normalize the PR gate review decision so UNKNOWN defaults to REVIEW_REQUIRED
- update the workflow guard test to cover the UNKNOWN normalization logic

## Testing
- pytest tests/test_pr_gate_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68eee5a7ce0483219e2239785d093b7b