### PR TITLE
Add retry loop constant and mock-based retry test

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -42,6 +42,8 @@ guards = ProviderGuards(cfg.providers)
 planner = RoutePlanner(cfg.router, cfg.providers)
 metrics = MetricsLogger(os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "metrics"))
 
+MAX_PROVIDER_ATTEMPTS = 3
+
 @app.get("/healthz")
 async def healthz():
     return {"status": "ok", "providers": list(cfg.providers.keys())}
@@ -83,7 +85,7 @@ async def chat_completions(req: Request, body: ChatRequest):
     for provider_name in [route.primary] + route.fallback:
         prov = providers.get(provider_name)
         guard = guards.get(provider_name)
-        for attempt in range(1, 4):
+        for attempt in range(1, MAX_PROVIDER_ATTEMPTS + 1):
             async with guard:
                 try:
                     resp = await prov.chat(
@@ -129,7 +131,7 @@ async def chat_completions(req: Request, body: ChatRequest):
                     )
                     return JSONResponse(chat_response_from_provider(resp))
 
-            if attempt < 3:
+            if attempt < MAX_PROVIDER_ATTEMPTS:
                 await asyncio.sleep(min(0.25 * attempt, 2.0))  # simple backoff
 
     return JSONResponse({"error": {"message": last_err or "all providers failed"}}, status_code=502)

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -6,6 +6,7 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
@@ -364,3 +365,50 @@ def test_chat_retries_success_after_transient_failures(
     assert success_records[0]["retries"] == 2
     failure_records = [record for record in records if record.get("ok") is False]
     assert [record["retries"] for record in failure_records] == [0, 1]
+
+
+def test_chat_retries_uses_three_attempts_with_mock(
+    route_test_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = load_app("1")
+    server_module = sys.modules["src.orch.server"]
+    records = capture_metric_records(server_module, monkeypatch)
+
+    async def no_sleep(_: float) -> None:
+        return None
+
+    from src.orch.types import ProviderChatResponse
+
+    success_response = ProviderChatResponse(
+        status_code=200,
+        model="dummy",
+        content="dummy:hi",
+    )
+
+    chat_mock = AsyncMock(
+        side_effect=[RuntimeError("fail-1"), RuntimeError("fail-2"), success_response]
+    )
+
+    class MockProvider:
+        model = "dummy"
+
+        def __init__(self) -> None:
+            self.chat = chat_mock
+
+    monkeypatch.setattr(server_module.asyncio, "sleep", no_sleep)
+    monkeypatch.setitem(server_module.providers.providers, "dummy", MockProvider())
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert response.status_code == 200
+    assert chat_mock.await_count == 3
+    success_records = [record for record in records if record.get("ok") is True]
+    assert len(success_records) == 1
+    assert success_records[0]["retries"] == 2


### PR DESCRIPTION
## Summary
- add an AsyncMock-backed test covering the three-attempt retry flow and metrics retries tracking
- extract a shared MAX_PROVIDER_ATTEMPTS constant to drive the retry loop and backoff condition

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eee611cb948321ac00bfe3153cacdb