### PR TITLE
Guard reflection artifact download on schedule

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
+        if: ${{ github.event_name == 'workflow_run' }}
         with:
           name: test-logs
           path: logs


### PR DESCRIPTION
## Summary
- skip downloading test logs when the reflection workflow runs on a scheduled trigger to avoid missing artifact failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eee9392eb48321a46bb3468352e6ea