### PR TITLE
Handle None chat request options with router defaults

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -81,16 +81,14 @@ async def chat_completions(req: Request, body: ChatRequest):
     usage_prompt = 0
     usage_completion = 0
     normalized_messages = [{"role": m.role, "content": m.content} for m in body.messages]
-    temperature = (
-        body.temperature
-        if "temperature" in body.model_fields_set
-        else cfg.router.defaults.temperature
-    )
-    max_tokens = (
-        body.max_tokens
-        if "max_tokens" in body.model_fields_set
-        else cfg.router.defaults.max_tokens
-    )
+    if "temperature" in body.model_fields_set and body.temperature is not None:
+        temperature = body.temperature
+    else:
+        temperature = cfg.router.defaults.temperature
+    if "max_tokens" in body.model_fields_set and body.max_tokens is not None:
+        max_tokens = body.max_tokens
+    else:
+        max_tokens = cfg.router.defaults.max_tokens
 
     for provider_name in [route.primary] + route.fallback:
         prov = providers.get(provider_name)


### PR DESCRIPTION
## Summary
- ensure the chat completions endpoint falls back to router defaults when temperature or max_tokens are omitted or null
- extend the server route test to cover omitted and explicit None request values via AsyncMock

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ef3fc0526883219e9ccd9940fc8d77