### PR TITLE
Ensure OpenAI provider skips Authorization header without token

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -30,8 +30,12 @@ class OpenAICompatProvider(BaseProvider):
             base_for_join = f"{base}/v1"
 
         url = urljoin(f"{base_for_join.rstrip('/')}/", "chat/completions")
-        key = os.environ.get(self.defn.auth_env or "", "")
-        headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        auth_env = self.defn.auth_env
+        if auth_env:
+            key = os.environ.get(auth_env, "")
+            if key:
+                headers["Authorization"] = f"Bearer {key}"
         payload = {"model": self.defn.model or model, "messages": messages, "temperature": temperature, "max_tokens": max_tokens, "stream": False}
         async with httpx.AsyncClient(timeout=60) as client:
             r = await client.post(url, headers=headers, json=payload)

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -64,6 +64,28 @@ def make_provider(base_url: str, defn_model: str = "gpt-4o") -> OpenAICompatProv
     return OpenAICompatProvider(provider_def)
 
 
+def test_no_authorization_header_when_auth_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    provider = OpenAICompatProvider(
+        ProviderDef(
+            name="openai-no-auth",
+            type="openai",
+            base_url="https://api.openai.com",
+            model="gpt-4o",
+            auth_env=None,
+            rpm=60,
+            concurrency=1,
+        )
+    )
+
+    post_calls, _ = run_chat(provider, monkeypatch)
+
+    assert post_calls
+    assert "Authorization" not in post_calls[0]["headers"]
+
+
 def test_openai_base_url_uses_chat_completions(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "secret")
     provider = make_provider("https://api.openai.com")


### PR DESCRIPTION
## Summary
- add a regression test ensuring OpenAI providers without auth configuration avoid sending Authorization headers
- adjust OpenAI-compatible provider to include the Authorization header only when a non-empty token is available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68efc97db05c8321bc7872480e7e0f37