### PR TITLE
Fix Anthropic base URL handling

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -73,7 +73,26 @@ class OpenAICompatProvider(BaseProvider):
 
 class AnthropicProvider(BaseProvider):
     async def chat(self, model: str, messages: List[dict[str, str]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
-        url = f"{self.defn.base_url.rstrip('/')}/v1/messages"
+        base = self.defn.base_url.rstrip("/")
+        parsed = urlparse(base)
+        path = parsed.path or ""
+        segments = [segment for segment in path.split("/") if segment]
+
+        def is_version_segment(segment: str) -> bool:
+            if not segment:
+                return False
+            lowered = segment.lower()
+            if not lowered.startswith("v"):
+                return False
+            suffix = lowered[1:]
+            return bool(suffix) and suffix[0].isdigit()
+
+        should_append_v1 = True
+        if segments and is_version_segment(segments[-1]):
+            should_append_v1 = False
+
+        base_for_join = base if not should_append_v1 else f"{base}/v1"
+        url = urljoin(f"{base_for_join.rstrip('/')}/", "messages")
         key = os.environ.get(self.defn.auth_env or "", "")
         headers = {"x-api-key": key, "anthropic-version": "2023-06-01", "Content-Type": "application/json"}
         system_messages = [m["content"] for m in messages if m["role"] == "system"]


### PR DESCRIPTION
## Summary
- add regression coverage for Anthropic providers using a base URL that already ends with v1
- prevent AnthropicProvider from appending an extra version segment when the base URL already includes one

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68efde1ae8e4832184432099df3a321e