### PR TITLE
Ensure test workflow uploads logs on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
           echo '{"name":"sample::ok","status":"pass","duration_ms":120}' >> logs/test.jsonl
           echo '{"name":"sample::fail","status":"fail","duration_ms":900}' >> logs/test.jsonl
       - name: Upload logs
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: test-logs
           path: logs
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- ensure the test workflow keeps the log upload step even when earlier steps fail
- avoid failing the job when the logs directory is absent

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68efe4225a9c83218fe163c72fe42f49