### PR TITLE
Adjust PR gate review handling

### DIFF
--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -38,8 +38,12 @@ jobs:
               core.warning('No review decision returned; defaulting to REVIEW_REQUIRED.');
             }
             const decision = (typeof rawDecision === 'string' ? rawDecision : undefined) ?? 'REVIEW_REQUIRED';
+            if (decision === 'CHANGES_REQUESTED') {
+              core.setFailed('Pull request has changes requested');
+              return;
+            }
             if (decision !== 'APPROVED') {
-              core.setFailed(`Pull request review decision is ${decision}`);
+              core.notice(`Pull request review decision is ${decision}`);
             }
       - name: Block auto-merge
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
           echo '{"name":"sample::ok","status":"pass","duration_ms":120}' >> logs/test.jsonl
           echo '{"name":"sample::fail","status":"fail","duration_ms":900}' >> logs/test.jsonl
       - name: Upload logs
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: test-logs
           path: logs
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- ensure the PR gate only fails when changes have been requested
- provide a notice instead of failing while reviews are still required

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68efe4225a9c83218fe163c72fe42f49