### PR TITLE
Ensure Anthropic provider omits API key when not configured

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -80,9 +80,11 @@ class AnthropicProvider(BaseProvider):
         }
         auth_env = self.defn.auth_env
         if auth_env:
-            key = os.environ.get(auth_env, "")
-            if key:
-                headers["x-api-key"] = key
+            raw_key = os.environ.get(auth_env)
+            if raw_key:
+                key = raw_key.strip()
+                if key:
+                    headers["x-api-key"] = key
         system_messages = [m["content"] for m in messages if m["role"] == "system"]
         mapped: list[dict[str, Any]] = []
         for message in messages:

--- a/tests/test_providers_anthropic.py
+++ b/tests/test_providers_anthropic.py
@@ -137,3 +137,25 @@ def test_anthropic_chat_omits_api_key_when_no_auth_env(monkeypatch: pytest.Monke
 
     request_headers = cast(dict[str, str], captured["headers"])
     assert "x-api-key" not in request_headers
+
+
+def test_anthropic_chat_omits_api_key_when_no_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider_def = ProviderDef(
+        name="anthropic",
+        type="anthropic",
+        base_url="https://api.anthropic.com",
+        model="claude-3-sonnet",
+        auth_env=None,
+        rpm=60,
+        concurrency=1,
+    )
+    provider = AnthropicProvider(provider_def)
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    messages = [{"role": "user", "content": "hello"}]
+
+    captured, _ = run_chat(provider, monkeypatch, messages)
+
+    request_headers = cast(dict[str, str], captured["headers"])
+    assert "x-api-key" not in request_headers


### PR DESCRIPTION
## Summary
- add regression test to verify Anthropic headers exclude x-api-key when no auth environment is configured
- trim Anthropic API key header handling so the key is only sent when a non-empty value is provided

## Testing
- pytest tests/test_providers_anthropic.py

------
https://chatgpt.com/codex/tasks/task_e_68eff3cedc588321ba9d2935ca5e4d0d