### PR TITLE
Add validation for empty provider types

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -180,10 +180,22 @@ class ProviderRegistry:
     def __init__(self, providers: Dict[str, ProviderDef]):
         self.providers = {}
         for name, d in providers.items():
-            provider_type = d.type or "openai"
+            provider_type_raw = d.type
+            provider_type = provider_type_raw if provider_type_raw is not None else "openai"
+
+            if isinstance(provider_type_raw, str) and not provider_type_raw.strip():
+                raise ValueError(
+                    f"Unknown provider type '<missing>' for provider '{name}'"
+                )
+
             factory = self._PROVIDER_FACTORIES.get(provider_type)
             if factory is None:
-                display_type = d.type if d.type else "<missing>"
+                display_type: str
+                if isinstance(provider_type_raw, str):
+                    stripped = provider_type_raw.strip()
+                    display_type = stripped if stripped else "<missing>"
+                else:
+                    display_type = provider_type
                 raise ValueError(
                     f"Unknown provider type '{display_type}' for provider '{name}'"
                 )

--- a/tests/test_providers_registry.py
+++ b/tests/test_providers_registry.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.orch.router import load_config  # noqa: E402
+from src.orch.providers import ProviderRegistry  # noqa: E402
+
+
+def test_provider_registry_rejects_empty_type(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "providers.toml").write_text(
+        """
+[alpha]
+type = ""
+base_url = "https://example.com"
+model = "gpt"
+auth_env = "TOKEN"
+rpm = 60
+concurrency = 4
+"""
+    )
+    (config_dir / "router.yaml").write_text(
+        """
+defaults:
+  temperature: 0.1
+  max_tokens: 128
+  task_header: x-orch-task-kind
+routes:
+  DEFAULT:
+    primary: alpha
+""",
+        encoding="utf-8",
+    )
+    loaded = load_config(str(config_dir))
+
+    with pytest.raises(ValueError) as excinfo:
+        ProviderRegistry(loaded.providers)
+
+    message = str(excinfo.value)
+    assert "alpha" in message
+    assert "<missing>" in message


### PR DESCRIPTION
## Summary
- add a regression test covering ProviderRegistry initialization with an empty provider type
- update ProviderRegistry to raise a ValueError when a provider definition has an empty type string

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f002e69c488321b4911e73a23fb165