### PR TITLE
Add tomli fallback for router config loading

### DIFF
--- a/src/orch/router.py
+++ b/src/orch/router.py
@@ -2,7 +2,11 @@ import os
 from dataclasses import dataclass
 from typing import Dict
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised via tests
+    import tomli as tomllib
+
 import yaml
 
 @dataclass


### PR DESCRIPTION
## Summary
- add a tomli fallback import in the router configuration loader so it works when tomllib is unavailable
- add coverage ensuring load_config succeeds when tomllib is missing

## Testing
- pytest tests/test_router_config.py

------
https://chatgpt.com/codex/tasks/task_e_68f006f72b94832193e47e97e724217b