### PR TITLE
Fix analyze p95 calculation for small samples

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -23,11 +23,25 @@ def compute_p95(durations: list[int]) -> int:
         return 0
     if len(durations) == 1:
         return int(durations[0])
+
+    sorted_durations = sorted(durations)
+    sample_count = len(sorted_durations)
+
+    if sample_count < 20:
+        try:
+            return int(
+                statistics.quantiles(
+                    sorted_durations, n=20, method="inclusive"
+                )[18]
+            )
+        except statistics.StatisticsError:
+            index = min(sample_count - 1, math.ceil(0.95 * sample_count) - 1)
+            return int(sorted_durations[index])
+
     try:
-        return int(statistics.quantiles(durations, n=20)[18])
+        return int(statistics.quantiles(sorted_durations, n=20)[18])
     except statistics.StatisticsError:
-        sorted_durations = sorted(durations)
-        index = min(len(sorted_durations) - 1, math.ceil(0.95 * len(sorted_durations)) - 1)
+        index = min(sample_count - 1, math.ceil(0.95 * sample_count) - 1)
         return int(sorted_durations[index])
 
 def main():

--- a/tests/test_scripts_analyze.py
+++ b/tests/test_scripts_analyze.py
@@ -32,3 +32,24 @@ def test_analyze_main_generates_report(tmp_path, monkeypatch):
     analyze.main()
 
     assert report_path.exists(), "Report file should be generated"
+
+
+def test_analyze_main_single_record_p95(tmp_path, monkeypatch):
+    log_path = tmp_path / "logs" / "test.jsonl"
+    report_path = tmp_path / "reports" / "today.md"
+    issue_path = tmp_path / "reports" / "issue_suggestions.md"
+
+    log_path.parent.mkdir(parents=True)
+    report_path.parent.mkdir(parents=True)
+
+    record = {"name": "sample::solo", "duration_ms": 123, "status": "pass"}
+    with log_path.open("w", encoding="utf-8") as fp:
+        fp.write(json.dumps(record) + "\n")
+
+    monkeypatch.setattr(analyze, "LOG", log_path)
+    monkeypatch.setattr(analyze, "REPORT", report_path)
+    monkeypatch.setattr(analyze, "ISSUE_OUT", issue_path)
+
+    analyze.main()
+
+    assert "- Duration p95: 123 ms" in report_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add coverage ensuring `scripts.analyze.main` handles a single log entry and emits the p95 value
- guard `compute_p95` by switching to inclusive quantiles for small samples with a manual percentile fallback

## Testing
- pytest tests/test_scripts_analyze.py

------
https://chatgpt.com/codex/tasks/task_e_68f02dcc95f88321ad7b8a987c5f87aa