### PR TITLE
Preserve query parameters when building OpenAI compat chat URL

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -1,6 +1,6 @@
 import os
 import re
-from urllib.parse import urljoin, urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse
 from typing import Dict, Any, List
 
 import httpx
@@ -47,9 +47,12 @@ class OpenAICompatProvider(BaseProvider):
         elif path_segments and is_version_segment(path_segments[-1]):
             should_append_v1 = False
 
-        base_for_join = f"{base}/v1" if should_append_v1 else base
-
-        url = urljoin(f"{base_for_join.rstrip('/')}/", "chat/completions")
+        normalized_segments = list(path_segments)
+        if should_append_v1:
+            normalized_segments.append("v1")
+        normalized_segments.extend(["chat", "completions"])
+        new_path = "/" + "/".join(normalized_segments)
+        url = urlunparse(parsed._replace(path=new_path))
         headers: dict[str, str] = {"Content-Type": "application/json"}
         auth_env = self.defn.auth_env
         if auth_env:

--- a/tests/test_providers_openai_compat.py
+++ b/tests/test_providers_openai_compat.py
@@ -96,3 +96,25 @@ def test_openai_compat_preserves_perplexity_base_url(monkeypatch: pytest.MonkeyP
     request_json = cast(dict[str, Any], captured["json"])
     assert request_json["stream"] is False
     assert response.content == "ok"
+
+
+def test_openai_compat_preserves_query_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider_def = ProviderDef(
+        name="azure-openai",
+        type="openai",
+        base_url="https://example.openai.azure.com/openai/deployments/foo?api-version=2024-02-01",
+        model="gpt-4o",
+        auth_env="AZURE_OPENAI_API_KEY",
+        rpm=60,
+        concurrency=1,
+    )
+
+    captured, response = _run_chat_and_capture(provider_def, "AZURE_OPENAI_API_KEY", monkeypatch)
+
+    assert (
+        captured["url"]
+        == "https://example.openai.azure.com/openai/deployments/foo/chat/completions?api-version=2024-02-01"
+    )
+    request_json = cast(dict[str, Any], captured["json"])
+    assert request_json["stream"] is False
+    assert response.content == "ok"


### PR DESCRIPTION
## Summary
- add a regression test covering Azure-style OpenAI compatible endpoints
- ensure OpenAICompatProvider appends chat/completions while preserving existing query strings

## Testing
- pytest tests/test_providers_openai_compat.py

------
https://chatgpt.com/codex/tasks/task_e_68f02dcbab748321b304359fbeeaca90