### PR TITLE
Handle empty logs in analyze script

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -46,15 +46,19 @@ def compute_p95(durations: list[int]) -> int:
 
 def main():
     tests, durs, fails = load_results()
-    total = len(tests) or 1
-    pass_rate = (total - len(fails)) / total
+    total = len(tests)
+    if total == 0:
+        pass_rate_text = "0.00%"
+    else:
+        pass_rate = (total - len(fails)) / total
+        pass_rate_text = f"{pass_rate:.2%}"
     p95 = compute_p95(durs)
     now = datetime.datetime.utcnow().isoformat()
     REPORT.parent.mkdir(parents=True, exist_ok=True)
     with REPORT.open("w", encoding="utf-8") as f:
         f.write(f"# Reflection Report ({now})\n\n")
         f.write(f"- Total tests: {total}\n")
-        f.write(f"- Pass rate: {pass_rate:.2%}\n")
+        f.write(f"- Pass rate: {pass_rate_text}\n")
         f.write(f"- Duration p95: {p95} ms\n")
         f.write(f"- Failures: {len(fails)}\n\n")
         if fails:

--- a/tests/test_scripts_analyze.py
+++ b/tests/test_scripts_analyze.py
@@ -34,6 +34,25 @@ def test_analyze_main_generates_report(tmp_path, monkeypatch):
     assert report_path.exists(), "Report file should be generated"
 
 
+def test_analyze_main_handles_empty_log(tmp_path, monkeypatch):
+    log_path = tmp_path / "logs" / "empty.jsonl"
+    report_path = tmp_path / "reports" / "today.md"
+    issue_path = tmp_path / "reports" / "issue_suggestions.md"
+
+    log_path.parent.mkdir(parents=True)
+    report_path.parent.mkdir(parents=True)
+    log_path.touch()
+
+    monkeypatch.setattr(analyze, "LOG", log_path)
+    monkeypatch.setattr(analyze, "REPORT", report_path)
+    monkeypatch.setattr(analyze, "ISSUE_OUT", issue_path)
+
+    analyze.main()
+
+    report_text = report_path.read_text(encoding="utf-8")
+    assert "- Pass rate: 0.00%" in report_text
+
+
 def test_analyze_main_single_record_p95(tmp_path, monkeypatch):
     log_path = tmp_path / "logs" / "test.jsonl"
     report_path = tmp_path / "reports" / "today.md"


### PR DESCRIPTION
## Summary
- add coverage ensuring scripts.analyze handles empty logs without errors
- emit a 0% pass rate when no tests are recorded instead of dividing by a placeholder

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f0306c09548321879c63e7bea70886