### PR TITLE
Ensure smoke chat curl fails on HTTP errors

### DIFF
--- a/tests/test_ci_smoke.py
+++ b/tests/test_ci_smoke.py
@@ -1,0 +1,15 @@
+import pathlib
+
+
+def test_chat_curl_uses_failfast_flag() -> None:
+    script_path = pathlib.Path('tools/ci/smoke.sh')
+    contents = script_path.read_text().splitlines()
+
+    curl_lines = [line for line in contents if line.strip().startswith('curl')]
+    assert len(curl_lines) >= 2, 'Expected at least two curl commands in smoke.sh'
+
+    second_curl = curl_lines[1]
+    assert any(
+        token.startswith('-') and 'f' in token[1:]
+        for token in second_curl.split()
+    ), 'Second curl invocation must include -f flag'

--- a/tools/ci/smoke.sh
+++ b/tools/ci/smoke.sh
@@ -4,5 +4,5 @@ uvicorn src.orch.server:app --port 31001 &
 PID=$!
 sleep 1
 curl -f http://localhost:31001/healthz
-curl -s -H 'Content-Type: application/json'   -d '{"model":"dummy","messages":[{"role":"user","content":"hi"}]}'   http://localhost:31001/v1/chat/completions >/dev/null
+curl -sf -H 'Content-Type: application/json'   -d '{"model":"dummy","messages":[{"role":"user","content":"hi"}]}'   http://localhost:31001/v1/chat/completions >/dev/null
 kill $PID


### PR DESCRIPTION
## Summary
- add a smoke test that verifies the chat curl command uses the failfast flag
- update the smoke script chat endpoint curl command to include -sf so HTTP errors cause failure

## Testing
- pytest tests/test_ci_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68f08d1f7ffc8321b461f35f0522b4d6