### PR TITLE
Add smoke curl flag test and enforce failfast

### DIFF
--- a/tests/test_ci_smoke_flags.py
+++ b/tests/test_ci_smoke_flags.py
@@ -1,0 +1,15 @@
+import pathlib
+
+
+def test_all_smoke_curl_commands_use_failfast_flag() -> None:
+    script_path = pathlib.Path("tools/ci/smoke.sh")
+    contents = script_path.read_text().splitlines()
+
+    curl_lines = [line.strip() for line in contents if line.strip().startswith("curl")]
+    assert len(curl_lines) >= 2, "Expected at least two curl commands in smoke.sh"
+
+    first_curl_tokens = curl_lines[0].split()
+    assert "-f" in first_curl_tokens, "Health check curl must include -f flag"
+
+    second_curl_tokens = curl_lines[1].split()
+    assert "-fs" in second_curl_tokens, "Chat curl must include -fs flags"

--- a/tools/ci/smoke.sh
+++ b/tools/ci/smoke.sh
@@ -4,5 +4,5 @@ uvicorn src.orch.server:app --port 31001 &
 PID=$!
 sleep 1
 curl -f http://localhost:31001/healthz
-curl -sf -H 'Content-Type: application/json'   -d '{"model":"dummy","messages":[{"role":"user","content":"hi"}]}'   http://localhost:31001/v1/chat/completions >/dev/null
+curl -fs -H 'Content-Type: application/json'   -d '{"model":"dummy","messages":[{"role":"user","content":"hi"}]}'   http://localhost:31001/v1/chat/completions >/dev/null
 kill $PID


### PR DESCRIPTION
## Summary
- add a pytest that verifies both curl commands in tools/ci/smoke.sh include failfast flags
- update the smoke CI script so the chat curl uses -fs for consistent failfast behavior

## Testing
- pytest tests/test_ci_smoke_flags.py tests/test_ci_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68f091305eb083219f0125cc63d4ede8