### PR TITLE
Handle Azure OpenAI api-key header in compat provider

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -25,6 +25,9 @@ class OpenAICompatProvider(BaseProvider):
         path_segments = [segment for segment in normalized_path.split("/") if segment]
         hostname = (parsed.netloc or "").lower()
         is_openai_host = hostname.endswith("openai.com")
+        is_azure_openai_host = hostname.endswith("openai.azure.com") or hostname.endswith(
+            "cognitiveservices.azure.com"
+        )
 
         def is_version_segment(segment: str) -> bool:
             if not segment:
@@ -59,7 +62,10 @@ class OpenAICompatProvider(BaseProvider):
         if auth_env:
             key = os.environ.get(auth_env, "")
             if key:
-                headers["Authorization"] = f"Bearer {key}"
+                if is_azure_openai_host:
+                    headers["api-key"] = key
+                else:
+                    headers["Authorization"] = f"Bearer {key}"
         payload = {
             "model": self.defn.model or model,
             "messages": messages,

--- a/tests/test_providers_openai_compat.py
+++ b/tests/test_providers_openai_compat.py
@@ -120,6 +120,24 @@ def test_openai_compat_preserves_query_parameters(monkeypatch: pytest.MonkeyPatc
     assert response.content == "ok"
 
 
+def test_openai_compat_azure_sets_api_key_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider_def = ProviderDef(
+        name="azure-openai",
+        type="openai",
+        base_url="https://example.openai.azure.com/openai/deployments/foo",
+        model="gpt-4o",
+        auth_env="AZURE_OPENAI_API_KEY",
+        rpm=60,
+        concurrency=1,
+    )
+
+    captured, _ = _run_chat_and_capture(provider_def, "AZURE_OPENAI_API_KEY", monkeypatch)
+
+    headers = cast(dict[str, str], captured["headers"])
+    assert headers["api-key"] == "secret"
+    assert "Authorization" not in headers
+
+
 def test_openai_compat_async_client_post_receives_query_string(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add coverage asserting Azure OpenAI requests include an api-key header
- update the OpenAI compatible provider to send api-key for Azure hosts while preserving bearer auth elsewhere

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f0913168508321988f7ecea254fe62