### PR TITLE
Ensure smoke curl commands enforce failfast

### DIFF
--- a/tests/test_ci_smoke.py
+++ b/tests/test_ci_smoke.py
@@ -13,3 +13,18 @@ def test_chat_curl_uses_failfast_flag() -> None:
         token.startswith('-') and 'f' in token[1:]
         for token in second_curl.split()
     ), 'Second curl invocation must include -f flag'
+
+
+def test_all_curl_commands_use_failfast_flag() -> None:
+    script_path = pathlib.Path('tools/ci/smoke.sh')
+    contents = script_path.read_text().splitlines()
+
+    curl_lines = [line.strip() for line in contents if line.strip().startswith('curl')]
+    assert curl_lines, 'Expected at least one curl command in smoke.sh'
+
+    for idx, curl_line in enumerate(curl_lines, start=1):
+        tokens = curl_line.split()
+        assert any(
+            token.startswith('-') and 'f' in token.lstrip('-')
+            for token in tokens[1:]
+        ), f'curl command #{idx} must include the -f flag'

--- a/tools/ci/smoke.sh
+++ b/tools/ci/smoke.sh
@@ -4,5 +4,8 @@ uvicorn src.orch.server:app --port 31001 &
 PID=$!
 sleep 1
 curl -f http://localhost:31001/healthz
-curl -fs -H 'Content-Type: application/json'   -d '{"model":"dummy","messages":[{"role":"user","content":"hi"}]}'   http://localhost:31001/v1/chat/completions >/dev/null
+curl -fs \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"dummy","messages":[{"role":"user","content":"hi"}]}' \
+  http://localhost:31001/v1/chat/completions >/dev/null
 kill $PID


### PR DESCRIPTION
## Summary
- add a regression test that checks every curl invocation in smoke.sh includes the failfast flag
- format the chat curl command with -fs to ensure HTTP errors surface during smoke runs

## Testing
- pytest tests/test_ci_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68f0d3390e088321b6788582499eb8fc