### PR TITLE
Fix Azure header detection for OpenAI compat

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -23,11 +23,14 @@ class OpenAICompatProvider(BaseProvider):
         path = parsed.path or ""
         normalized_path = path.rstrip("/")
         path_segments = [segment for segment in normalized_path.split("/") if segment]
-        hostname = (parsed.netloc or "").lower()
+        hostname = (parsed.hostname or "").lower()
+        azure_compat_suffixes = ("openai.azure.com", "cognitiveservices.azure.com")
+
+        def _matches_suffix(host: str, suffix: str) -> bool:
+            return host == suffix or host.endswith(f".{suffix}")
+
         is_openai_host = hostname.endswith("openai.com")
-        is_azure_openai_host = hostname.endswith("openai.azure.com") or hostname.endswith(
-            "cognitiveservices.azure.com"
-        )
+        is_azure_openai_host = any(_matches_suffix(hostname, suffix) for suffix in azure_compat_suffixes)
 
         def is_version_segment(segment: str) -> bool:
             if not segment:

--- a/tests/test_providers_openai_compat.py
+++ b/tests/test_providers_openai_compat.py
@@ -138,6 +138,26 @@ def test_openai_compat_azure_sets_api_key_header(monkeypatch: pytest.MonkeyPatch
     assert "Authorization" not in headers
 
 
+def test_openai_compat_azure_with_port_uses_api_key_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_def = ProviderDef(
+        name="azure-openai",
+        type="openai",
+        base_url="https://example.openai.azure.com:443/openai/deployments/foo",
+        model="gpt-4o",
+        auth_env="AZURE_OPENAI_API_KEY",
+        rpm=60,
+        concurrency=1,
+    )
+
+    captured, _ = _run_chat_and_capture(provider_def, "AZURE_OPENAI_API_KEY", monkeypatch)
+
+    headers = cast(dict[str, str], captured["headers"])
+    assert headers["api-key"] == "secret"
+    assert "Authorization" not in headers
+
+
 def test_openai_compat_async_client_post_receives_query_string(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure Azure-compatible hosts use the api-key header even when a port is present
- add regression coverage for Azure base URLs that include an explicit port

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f0d338f6c48321ba41262356e513d2