### PR TITLE
Preserve tool call metadata in chat responses

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -167,11 +167,15 @@ class AnthropicProvider(BaseProvider):
             if isinstance(block, dict) and block.get("type") == "text"
         )
         usage = data.get("usage") or {}
+        finish_reason = data.get("stop_reason")
+        tool_calls = data.get("tool_calls")
         response_model = data.get("model") or self.defn.model or model
         return ProviderChatResponse(
             status_code=r.status_code,
             model=response_model,
             content=content,
+            finish_reason=finish_reason,
+            tool_calls=tool_calls,
             usage_prompt_tokens=usage.get("input_tokens", 0),
             usage_completion_tokens=usage.get("output_tokens", 0),
         )

--- a/src/orch/types.py
+++ b/src/orch/types.py
@@ -16,7 +16,7 @@ class ChatRequest(BaseModel):
 class ProviderChatResponse(BaseModel):
     status_code: int = 200
     model: str
-    content: str | None
+    content: str | list[dict[str, Any]] | None = None
     finish_reason: str | None = None
     tool_calls: list[dict[str, Any]] | None = None
     usage_prompt_tokens: Optional[int] = 0

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -135,6 +135,59 @@ def test_chat_accepts_tool_role_messages(
     assert records[-1]["status"] == 200
 
 
+def test_chat_response_includes_tool_calls(
+    route_test_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = load_app("1")
+    server_module = sys.modules["src.orch.server"]
+    records = capture_metric_records(server_module, monkeypatch)
+
+    from src.orch.types import ProviderChatResponse
+
+    tool_calls = [
+        {
+            "id": "call_123",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": "{\"key\": \"value\"}"},
+        }
+    ]
+    provider_chat = AsyncMock(
+        return_value=ProviderChatResponse(
+            status_code=200,
+            model="dummy",
+            finish_reason="tool_calls",
+            tool_calls=tool_calls,
+        )
+    )
+
+    class MockProvider:
+        model = "dummy"
+
+        def __init__(self) -> None:
+            self.chat = provider_chat
+
+    monkeypatch.setitem(server_module.providers.providers, "dummy", MockProvider())
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert response.status_code == 200
+    provider_chat.assert_awaited_once()
+    body = response.json()
+    choice = body["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["tool_calls"] == tool_calls
+    assert "content" not in choice["message"]
+    assert records
+    assert records[-1]["status"] == 200
+
+
 def test_chat_rejects_stream_requests(
     route_test_config: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add regression coverage for tool call-only responses at the provider layer and HTTP route
- allow `ProviderChatResponse` to omit content while preserving upstream `finish_reason` and `tool_calls`
- propagate Anthropics `stop_reason`/`tool_calls` into chat responses for client serialization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f0fc6582b483218b6049b7042ec801