### PR TITLE
Support tool chat payload passthrough

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -13,11 +13,11 @@ class BaseProvider:
         self.defn = defn
         self.model = defn.model
 
-    async def chat(self, model: str, messages: List[dict[str, str]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
+    async def chat(self, model: str, messages: List[dict[str, Any]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
         raise NotImplementedError
 
 class OpenAICompatProvider(BaseProvider):
-    async def chat(self, model: str, messages: List[dict[str, str]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
+    async def chat(self, model: str, messages: List[dict[str, Any]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
         raw_base = self.defn.base_url.strip()
         parsed = urlparse(raw_base)
         path = parsed.path or ""
@@ -98,7 +98,7 @@ class OpenAICompatProvider(BaseProvider):
         )
 
 class AnthropicProvider(BaseProvider):
-    async def chat(self, model: str, messages: List[dict[str, str]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
+    async def chat(self, model: str, messages: List[dict[str, Any]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
         base = self.defn.base_url.strip()
         parsed = urlparse(base)
         path = parsed.path or ""
@@ -177,7 +177,7 @@ class AnthropicProvider(BaseProvider):
         )
 
 class OllamaProvider(BaseProvider):
-    async def chat(self, model: str, messages: List[dict[str, str]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
+    async def chat(self, model: str, messages: List[dict[str, Any]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
         url = f"{self.defn.base_url.rstrip('/')}/api/chat"
         payload = {"model": self.defn.model or model, "messages": messages, "stream": False, "options": {"temperature": temperature, "num_predict": max_tokens}}
         async with httpx.AsyncClient(timeout=120) as client:
@@ -189,7 +189,7 @@ class OllamaProvider(BaseProvider):
         return ProviderChatResponse(status_code=r.status_code, model=self.defn.model or model, content=content)
 
 class DummyProvider(BaseProvider):
-    async def chat(self, model: str, messages: List[dict[str, str]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
+    async def chat(self, model: str, messages: List[dict[str, Any]], temperature=0.2, max_tokens=2048) -> ProviderChatResponse:
         # simple echo-ish behavior for tests
         last_user = next((m["content"] for m in reversed(messages) if m["role"]=="user"), "ping")
         return ProviderChatResponse(status_code=200, model="dummy", content=f"dummy:{last_user}")

--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -140,7 +140,7 @@ async def chat_completions(req: Request, body: ChatRequest):
     last_model = body.model
     success_response: ProviderChatResponse | None = None
     success_record: dict[str, object] | None = None
-    normalized_messages = [{"role": m.role, "content": m.content} for m in body.messages]
+    normalized_messages = [m.model_dump(exclude_none=True) for m in body.messages]
     if "temperature" in body.model_fields_set and body.temperature is not None:
         temperature = body.temperature
     else:

--- a/src/orch/types.py
+++ b/src/orch/types.py
@@ -1,17 +1,26 @@
-
 from typing import Any, Dict, List, Literal, Optional, Union
-from pydantic import BaseModel, Field
+
+from pydantic import BaseModel, ConfigDict
+
 
 class ChatMessage(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     role: Literal["system", "user", "assistant", "tool"]
     content: Union[str, List[Dict[str, Any]], None]
+    name: Optional[str] = None
+    tool_call_id: Optional[str] = None
+
 
 class ChatRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     model: str
     messages: List[ChatMessage]
     temperature: Optional[float] = 0.2
     max_tokens: Optional[int] = 2048
     stream: Optional[bool] = False
+
 
 class ProviderChatResponse(BaseModel):
     status_code: int = 200
@@ -22,29 +31,35 @@ class ProviderChatResponse(BaseModel):
     usage_prompt_tokens: Optional[int] = 0
     usage_completion_tokens: Optional[int] = 0
 
+
 def chat_response_from_provider(p: ProviderChatResponse) -> dict[str, Any]:
-    import time, uuid
+    import time
+    import uuid
+
     return {
         "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
         "object": "chat.completion",
         "created": int(time.time()),
         "model": p.model,
-        "choices": [{
-            "index": 0,
-            "message": {
-                key: value
-                for key, value in {
-                    "role": "assistant",
-                    "content": p.content,
-                    "tool_calls": p.tool_calls,
-                }.items()
-                if value is not None
-            },
-            "finish_reason": p.finish_reason or "stop"
-        }],
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    key: value
+                    for key, value in {
+                        "role": "assistant",
+                        "content": p.content,
+                        "tool_calls": p.tool_calls,
+                    }.items()
+                    if value is not None
+                },
+                "finish_reason": p.finish_reason or "stop",
+            }
+        ],
         "usage": {
             "prompt_tokens": p.usage_prompt_tokens or 0,
             "completion_tokens": p.usage_completion_tokens or 0,
-            "total_tokens": (p.usage_prompt_tokens or 0) + (p.usage_completion_tokens or 0)
-        }
+            "total_tokens": (p.usage_prompt_tokens or 0)
+            + (p.usage_completion_tokens or 0),
+        },
     }

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -94,6 +94,12 @@ def test_chat_accepts_tool_role_messages(
     from src.orch.types import ProviderChatResponse
 
     tool_content = [{"type": "output_text", "text": "done"}]
+    tool_message = {
+        "role": "tool",
+        "name": "browser",
+        "tool_call_id": "call-1",
+        "content": tool_content,
+    }
     provider_chat = AsyncMock(
         return_value=ProviderChatResponse(
             status_code=200,
@@ -117,7 +123,7 @@ def test_chat_accepts_tool_role_messages(
             "model": "dummy",
             "messages": [
                 {"role": "user", "content": "hi"},
-                {"role": "tool", "content": tool_content},
+                tool_message,
             ],
         },
     )
@@ -128,7 +134,7 @@ def test_chat_accepts_tool_role_messages(
     assert called_args[0] == "dummy"
     assert called_args[1] == [
         {"role": "user", "content": "hi"},
-        {"role": "tool", "content": tool_content},
+        tool_message,
     ]
     assert records
     assert all(record.get("status") != 422 for record in records)


### PR DESCRIPTION
## Summary
- allow chat requests to retain tool metadata such as name and tool_call_id
- forward full message payloads to providers without dropping fields
- extend server route test to ensure tool messages with structured content reach providers unchanged

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f0fc66887c83219fe479465a825c68