### PR TITLE
Handle string tool_choice values

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -43,7 +43,11 @@ def _normalize_anthropic_tools(tools: list[dict[str, Any]]) -> list[dict[str, An
     return [_normalize_anthropic_tool(tool) for tool in tools]
 
 
-def _normalize_anthropic_tool_choice(tool_choice: dict[str, Any]) -> dict[str, Any]:
+def _normalize_anthropic_tool_choice(
+    tool_choice: dict[str, Any] | str,
+) -> dict[str, Any] | str:
+    if isinstance(tool_choice, str):
+        return tool_choice
     choice_type = tool_choice.get("type")
     if choice_type != "function":
         return dict(tool_choice)
@@ -484,7 +488,7 @@ class DummyProvider(BaseProvider):
         max_tokens=2048,
         *,
         tools: list[dict[str, Any]] | None = None,
-        tool_choice: dict[str, Any] | None = None,
+        tool_choice: dict[str, Any] | str | None = None,
         function_call: dict[str, Any] | str | None = None,
     ) -> ProviderChatResponse:
         # simple echo-ish behavior for tests

--- a/src/orch/types.py
+++ b/src/orch/types.py
@@ -23,7 +23,7 @@ class ChatRequest(BaseModel):
     max_tokens: Optional[int] = 2048
     stream: Optional[bool] = False
     tools: Optional[List[Dict[str, Any]]] = None
-    tool_choice: Optional[Dict[str, Any]] = None
+    tool_choice: Optional[Union[str, Dict[str, Any]]] = None
 
 
 class ProviderChatResponse(BaseModel):

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -198,6 +198,56 @@ def test_chat_preserves_message_extra_fields(
     assert records[-1]["status"] == 200
 
 
+def test_chat_accepts_tool_choice_strings(
+    route_test_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = load_app("1")
+    server_module = sys.modules["src.orch.server"]
+    records = capture_metric_records(server_module, monkeypatch)
+
+    from src.orch.types import ProviderChatResponse
+
+    client = TestClient(app)
+
+    def run_case(tool_choice: str) -> None:
+        provider_chat = AsyncMock(
+            return_value=ProviderChatResponse(
+                status_code=200,
+                model="dummy",
+                content="ok",
+            )
+        )
+
+        class MockProvider:
+            model = "dummy"
+
+            def __init__(self) -> None:
+                self.chat = provider_chat
+
+        monkeypatch.setitem(
+            server_module.providers.providers, "dummy", MockProvider()
+        )
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "dummy",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tool_choice": tool_choice,
+            },
+        )
+
+        assert response.status_code == 200
+        provider_chat.assert_awaited_once()
+        assert provider_chat.await_args.kwargs["tool_choice"] == tool_choice
+
+    run_case("auto")
+    run_case("none")
+
+    assert records
+    assert records[-1]["status"] == 200
+
+
 def test_chat_forwards_tools_to_provider(
     route_test_config: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add regression coverage ensuring chat completions accept string tool_choice values
- allow ChatRequest and provider normalization to forward string tool_choice without validation errors

## Testing
- pytest tests/test_server_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68f16eaaeac48321849edc68aef5f21c