### PR TITLE
Preserve list content in OpenAI chat responses

### DIFF
--- a/src/orch/types.py
+++ b/src/orch/types.py
@@ -29,7 +29,7 @@ class ChatRequest(BaseModel):
 class ProviderChatResponse(BaseModel):
     status_code: int = 200
     model: str
-    content: str | None = None
+    content: str | list[dict[str, Any]] | None = None
     finish_reason: str | None = None
     tool_calls: list[dict[str, Any]] | None = None
     function_call: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary
- allow `ProviderChatResponse` to carry structured list content from upstream provider messages
- add coverage ensuring OpenAI chat responses keep list-form content when serialized back to payloads

## Testing
- pytest tests/test_providers_openai.py

------
https://chatgpt.com/codex/tasks/task_e_68f175328fb08321bd394a7dad3c60ed