### PR TITLE
Ensure sampling options propagate through server

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -88,6 +88,11 @@ class BaseProvider:
         tools: list[dict[str, Any]] | None = None,
         tool_choice: dict[str, Any] | str | None = None,
         function_call: dict[str, Any] | str | None = None,
+        top_p: float | None = None,
+        frequency_penalty: float | None = None,
+        presence_penalty: float | None = None,
+        logit_bias: dict[str, float] | None = None,
+        response_format: dict[str, Any] | None = None,
         **extra_options: Any,
     ) -> ProviderChatResponse:
         raise NotImplementedError
@@ -116,6 +121,11 @@ class OpenAICompatProvider(BaseProvider):
         tools: list[dict[str, Any]] | None = None,
         tool_choice: dict[str, Any] | str | None = None,
         function_call: dict[str, Any] | str | None = None,
+        top_p: float | None = None,
+        frequency_penalty: float | None = None,
+        presence_penalty: float | None = None,
+        logit_bias: dict[str, float] | None = None,
+        response_format: dict[str, Any] | None = None,
         **extra_options: Any,
     ) -> ProviderChatResponse:
         raw_base = self.defn.base_url.strip()
@@ -182,6 +192,16 @@ class OpenAICompatProvider(BaseProvider):
             payload["tool_choice"] = tool_choice
         if function_call is not None:
             payload["function_call"] = function_call
+        if top_p is not None:
+            payload["top_p"] = top_p
+        if frequency_penalty is not None:
+            payload["frequency_penalty"] = frequency_penalty
+        if presence_penalty is not None:
+            payload["presence_penalty"] = presence_penalty
+        if logit_bias is not None:
+            payload["logit_bias"] = logit_bias
+        if response_format is not None:
+            payload["response_format"] = response_format
         self._merge_extra_options(payload, extra_options)
         async with httpx.AsyncClient(timeout=60) as client:
             r = await client.post(url, headers=headers, json=payload)
@@ -217,6 +237,11 @@ class AnthropicProvider(BaseProvider):
         tools: list[dict[str, Any]] | None = None,
         tool_choice: dict[str, Any] | str | None = None,
         function_call: dict[str, Any] | str | None = None,
+        top_p: float | None = None,
+        frequency_penalty: float | None = None,
+        presence_penalty: float | None = None,
+        logit_bias: dict[str, float] | None = None,
+        response_format: dict[str, Any] | None = None,
         **extra_options: Any,
     ) -> ProviderChatResponse:
         base = self.defn.base_url.strip()
@@ -511,6 +536,11 @@ class OllamaProvider(BaseProvider):
         tools: list[dict[str, Any]] | None = None,
         tool_choice: dict[str, Any] | str | None = None,
         function_call: dict[str, Any] | str | None = None,
+        top_p: float | None = None,
+        frequency_penalty: float | None = None,
+        presence_penalty: float | None = None,
+        logit_bias: dict[str, float] | None = None,
+        response_format: dict[str, Any] | None = None,
         **extra_options: Any,
     ) -> ProviderChatResponse:
         url = f"{self.defn.base_url.rstrip('/')}/api/chat"
@@ -558,6 +588,11 @@ class DummyProvider(BaseProvider):
         tools: list[dict[str, Any]] | None = None,
         tool_choice: dict[str, Any] | str | None = None,
         function_call: dict[str, Any] | str | None = None,
+        top_p: float | None = None,
+        frequency_penalty: float | None = None,
+        presence_penalty: float | None = None,
+        logit_bias: dict[str, float] | None = None,
+        response_format: dict[str, Any] | None = None,
         **extra_options: Any,
     ) -> ProviderChatResponse:
         # simple echo-ish behavior for tests

--- a/src/orch/types.py
+++ b/src/orch/types.py
@@ -24,6 +24,11 @@ class ChatRequest(BaseModel):
     stream: Optional[bool] = False
     tools: Optional[List[Dict[str, Any]]] = None
     tool_choice: Optional[Union[str, Dict[str, Any]]] = None
+    top_p: Optional[float] = None
+    frequency_penalty: Optional[float] = None
+    presence_penalty: Optional[float] = None
+    logit_bias: Optional[Dict[str, float]] = None
+    response_format: Optional[Dict[str, Any]] = None
 
 
 class ProviderChatResponse(BaseModel):

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -315,6 +315,8 @@ def test_chat_forwards_extra_options(
 
     extra_options = {
         "top_p": 0.42,
+        "frequency_penalty": 1.25,
+        "presence_penalty": -0.5,
         "response_format": {"type": "json_object"},
     }
 
@@ -346,6 +348,8 @@ def test_chat_forwards_extra_options(
     provider_chat.assert_awaited_once()
     kwargs = provider_chat.await_args.kwargs
     assert kwargs["top_p"] == extra_options["top_p"]
+    assert kwargs["frequency_penalty"] == extra_options["frequency_penalty"]
+    assert kwargs["presence_penalty"] == extra_options["presence_penalty"]
     assert kwargs["response_format"] == extra_options["response_format"]
 
     from src.orch.providers import OpenAICompatProvider
@@ -382,6 +386,8 @@ def test_chat_forwards_extra_options(
     assert openai_calls
     payload = openai_calls[0]["json"]
     assert payload["top_p"] == extra_options["top_p"]
+    assert payload["frequency_penalty"] == extra_options["frequency_penalty"]
+    assert payload["presence_penalty"] == extra_options["presence_penalty"]
     assert payload["response_format"] == extra_options["response_format"]
 
 


### PR DESCRIPTION
## Summary
- extend ChatRequest parsing and server forwarding so sampling options like top_p/frequency_penalty are preserved when calling providers
- update the provider chat interfaces to accept these parameters and ensure OpenAI-compatible payloads include them
- tighten regression coverage for server routing and OpenAI compatibility around the additional sampling parameters

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f1cf82f2748321986eb4c57638960c