### PR TITLE
Handle Anthropic function_call none disabling tools

### DIFF
--- a/tests/test_providers_anthropic.py
+++ b/tests/test_providers_anthropic.py
@@ -176,6 +176,36 @@ def test_anthropic_payload_includes_tools(monkeypatch: pytest.MonkeyPatch) -> No
     assert request_json["tool_choice"] == tool_choice
 
 
+def test_anthropic_function_call_none_disables_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = build_anthropic_provider(monkeypatch)
+    tools = [
+        {
+            "name": "lookup",
+            "description": "Lookup data",
+            "input_schema": {
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+                "required": ["q"],
+            },
+        }
+    ]
+
+    captured, _ = run_chat(
+        provider,
+        monkeypatch,
+        messages=[{"role": "user", "content": "hello"}],
+        tools=tools,
+        tool_choice={"type": "tool", "name": "lookup"},
+        function_call="none",
+    )
+
+    request_json = cast(dict[str, Any], captured["json"])
+    assert "tools" not in request_json
+    assert request_json.get("tool_choice") == "none"
+
+
 def test_anthropic_payload_applies_function_call_name(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = build_anthropic_provider(monkeypatch)
     tools = [


### PR DESCRIPTION
## Summary
- add coverage for function_call="none" behavior in Anthropic provider payloads
- disable Anthropic tool definitions when function_call requests none and propagate string modes to tool_choice

## Testing
- pytest tests/test_providers_anthropic.py

------
https://chatgpt.com/codex/tasks/task_e_68f1d22733b88321a134e629a87d52c4