### PR TITLE
Fix Anthropic base URL version normalization

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -266,9 +266,11 @@ class AnthropicProvider(BaseProvider):
         has_version_segment = any(is_version_segment(segment) for segment in normalized_segments)
 
         if normalized_segments:
-            if normalized_segments[-1].lower() != "messages":
-                if not has_version_segment:
-                    normalized_segments.append("v1")
+            ends_with_messages = normalized_segments[-1].lower() == "messages"
+            if not has_version_segment:
+                insert_index = len(normalized_segments) - 1 if ends_with_messages else len(normalized_segments)
+                normalized_segments.insert(insert_index, "v1")
+            if not ends_with_messages:
                 normalized_segments.append("messages")
         else:
             normalized_segments = ["v1", "messages"]


### PR DESCRIPTION
## Summary
- add regression tests covering Anthropic base URLs that already end with `messages`
- ensure the Anthropic provider inserts the `v1` segment ahead of the messages endpoint when missing

## Testing
- pytest tests/test_providers_anthropic.py

------
https://chatgpt.com/codex/tasks/task_e_68f1d4de538883218c6315b3b92acb85