### PR TITLE
Handle Azure regional domains for OpenAI compat

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -138,7 +138,14 @@ class OpenAICompatProvider(BaseProvider):
         normalized_path = path.rstrip("/")
         path_segments = [segment for segment in normalized_path.split("/") if segment]
         hostname = (parsed.hostname or "").lower()
-        azure_compat_suffixes = ("openai.azure.com", "cognitiveservices.azure.com")
+        azure_compat_suffixes = (
+            "openai.azure.com",
+            "openai.azure.us",
+            "openai.azure.cn",
+            "cognitiveservices.azure.com",
+            "cognitiveservices.azure.us",
+            "cognitiveservices.azure.cn",
+        )
 
         def _matches_suffix(host: str, suffix: str) -> bool:
             return host == suffix or host.endswith(f".{suffix}")

--- a/tests/test_providers_openai_compat.py
+++ b/tests/test_providers_openai_compat.py
@@ -133,31 +133,22 @@ def test_openai_compat_preserves_query_parameters(monkeypatch: pytest.MonkeyPatc
     assert response.content == "ok"
 
 
-def test_openai_compat_azure_sets_api_key_header(monkeypatch: pytest.MonkeyPatch) -> None:
-    provider_def = ProviderDef(
-        name="azure-openai",
-        type="openai",
-        base_url="https://example.openai.azure.com/openai/deployments/foo",
-        model="gpt-4o",
-        auth_env="AZURE_OPENAI_API_KEY",
-        rpm=60,
-        concurrency=1,
-    )
-
-    captured, _ = _run_chat_and_capture(provider_def, "AZURE_OPENAI_API_KEY", monkeypatch)
-
-    headers = cast(dict[str, str], captured["headers"])
-    assert headers["api-key"] == "secret"
-    assert "Authorization" not in headers
-
-
-def test_openai_compat_azure_with_port_uses_api_key_header(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://example.openai.azure.com/openai/deployments/foo",
+        "https://example.openai.azure.com:443/openai/deployments/foo",
+        "https://example.openai.azure.us/openai/deployments/foo",
+        "https://example.openai.azure.cn/openai/deployments/foo",
+    ],
+)
+def test_openai_compat_azure_variants_use_api_key_header(
+    base_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     provider_def = ProviderDef(
         name="azure-openai",
         type="openai",
-        base_url="https://example.openai.azure.com:443/openai/deployments/foo",
+        base_url=base_url,
         model="gpt-4o",
         auth_env="AZURE_OPENAI_API_KEY",
         rpm=60,


### PR DESCRIPTION
## Summary
- cover Azure OpenAI regional hostnames ending in .azure.us and .azure.cn when selecting header auth
- extend OpenAI compatibility tests to ensure api-key header is used for Azure domains including regional variants

## Testing
- pytest tests/test_providers_openai_compat.py

------
https://chatgpt.com/codex/tasks/task_e_68f1d4ddfc548321a456a51632c3ea06