### PR TITLE
Normalize Anthropic stop reason handling

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -558,7 +558,14 @@ class AnthropicProvider(BaseProvider):
 
         content = "".join(text_parts)
         finish_reason_raw = data.get("stop_reason")
-        finish_reason = "tool_calls" if finish_reason_raw == "tool_use" else finish_reason_raw
+        stop_reason_map = {
+            "tool_use": "tool_calls",
+            "max_tokens": "length",
+            "message_limit": "length",
+            "end_turn": "stop",
+            "stop_sequence": "stop",
+        }
+        finish_reason = stop_reason_map.get(finish_reason_raw, finish_reason_raw)
         normalized_tool_calls = tool_calls or None
         usage = data.get("usage") or {}
         response_model = data.get("model") or self.defn.model or model


### PR DESCRIPTION
## Summary
- add coverage ensuring Anthropic stop reasons are normalized for OpenAI-compatible responses
- normalize Anthropic stop reasons like `max_tokens`, `end_turn`, and `stop_sequence` to OpenAI `finish_reason` values while keeping tool call mapping

## Testing
- pytest tests/test_providers_anthropic.py

------
https://chatgpt.com/codex/tasks/task_e_68f1e8fea54083218eb165a6eafe07b0