### PR TITLE
Ensure Anthropc tool-only responses omit content

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -556,7 +556,11 @@ class AnthropicProvider(BaseProvider):
                 result_content = block.get("content")
                 text_parts.append(normalize_text_content(result_content))
 
-        content = "".join(text_parts) if text_parts else None
+        if text_parts:
+            joined_content = "".join(text_parts)
+            content: str | None = joined_content if joined_content else None
+        else:
+            content = None
         finish_reason_raw = data.get("stop_reason")
         stop_reason_map = {
             "tool_use": "tool_calls",


### PR DESCRIPTION
## Summary
- add a regression test covering tool-only Anthropc responses
- ensure Anthropc provider omits response content when no text is returned

## Testing
- pytest tests/test_providers_anthropic.py

------
https://chatgpt.com/codex/tasks/task_e_68f1efd10748832193acf96cc7326bc1