### PR TITLE
Handle missing test logs artifact in reflection workflow

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -15,10 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
+        id: fetch-logs
         if: ${{ github.event_name == 'workflow_run' }}
+        continue-on-error: true
         with:
           name: test-logs
           path: logs
+      - name: Warn when logs artifact is unavailable
+        if: ${{ steps.fetch-logs.outcome == 'failure' }}
+        run: |
+          echo "::warning::test-logs artifact not found; continuing without log import"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- allow the reflection workflow to continue even when the test-logs artifact is unavailable
- emit a warning so that missing artifacts are still visible in the logs

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f1f9a21ec88321b2d9040c34573d3f