### PR TITLE
chore(ci): remove unsupported download artifact input

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           name: test-logs
           path: logs
-          if-no-artifact-found: warn
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- drop the deprecated `if-no-artifact-found` input from the reflection workflow download step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f203c686ec8321a96a0ca3530bc32e