### PR TITLE
Fix reflection workflow artifact download

### DIFF
--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -20,6 +20,7 @@ jobs:
         continue-on-error: true
         with:
           name: test-logs
+          run-id: ${{ github.event.workflow_run.id }}
           path: logs
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- ensure the reflection workflow downloads the test log artifact from the triggering test run

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f2092d68d483218af2f75838d89805