### PR TITLE
Handle blank lines in analyze log parser

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -30,7 +30,10 @@ def load_results():
         return tests, durs, fails
     with LOG.open() as f:
         for line in f:
-            obj = json.loads(line)
+            stripped = line.strip()
+            if not stripped:
+                continue
+            obj = json.loads(stripped)
             tests.append(obj.get("name"))
             durs.append(_normalize_duration(obj.get("duration_ms", 0)))
             if obj.get("status") == "fail":

--- a/tests/test_scripts_analyze.py
+++ b/tests/test_scripts_analyze.py
@@ -34,6 +34,34 @@ def test_analyze_main_generates_report(tmp_path, monkeypatch):
     assert report_path.exists(), "Report file should be generated"
 
 
+def test_analyze_main_handles_blank_lines(tmp_path, monkeypatch):
+    log_path = tmp_path / "logs" / "test.jsonl"
+    report_path = tmp_path / "reports" / "today.md"
+    issue_path = tmp_path / "reports" / "issue_suggestions.md"
+
+    log_path.parent.mkdir(parents=True)
+    report_path.parent.mkdir(parents=True)
+
+    records = [
+        {"name": "sample::test_one", "duration_ms": 10, "status": "pass"},
+        {"name": "sample::test_two", "duration_ms": 20, "status": "fail"},
+    ]
+
+    with log_path.open("w", encoding="utf-8") as fp:
+        fp.write("\n")
+        for record in records:
+            fp.write(json.dumps(record) + "\n\n")
+        fp.write("   \n")
+
+    monkeypatch.setattr(analyze, "LOG", log_path)
+    monkeypatch.setattr(analyze, "REPORT", report_path)
+    monkeypatch.setattr(analyze, "ISSUE_OUT", issue_path)
+
+    analyze.main()
+
+    assert report_path.exists(), "Report file should be generated even with blank lines"
+
+
 def test_analyze_main_reports_no_tests_when_log_missing(tmp_path, monkeypatch):
     report_path = tmp_path / "reports" / "today.md"
     issue_path = tmp_path / "reports" / "issue_suggestions.md"


### PR DESCRIPTION
## Summary
- add coverage ensuring analyze.main processes logs with blank lines
- skip empty or whitespace-only lines when loading analyze results

## Testing
- pytest tests/test_scripts_analyze.py

------
https://chatgpt.com/codex/tasks/task_e_68f2255c8184832183e101cb08eaa0c7