### PR TITLE
style: group imports in front matter check

### DIFF
--- a/workflow-cookbook-main/tools/ci/check_front_matter.py
+++ b/workflow-cookbook-main/tools/ci/check_front_matter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+
 from pathlib import Path
 from typing import Dict, Iterable, List, Sequence
 


### PR DESCRIPTION
## Summary
- separate the standard-library CLI imports from the remaining imports in the front matter check script for clarity

## Testing
- python -m ruff check workflow-cookbook-main/tools/ci/check_front_matter.py
- python workflow-cookbook-main/tools/ci/check_front_matter.py --check

------
https://chatgpt.com/codex/tasks/task_e_68f22fe93d3883219f4f3ccf1783e74f