### PR TITLE
Add duration_ms to pytest JUnit export records

### DIFF
--- a/scripts/export_pytest_junit.py
+++ b/scripts/export_pytest_junit.py
@@ -57,6 +57,7 @@ def _build_record(testcase: ET.Element) -> dict[str, object]:
     }
     if time_value is not None:
         record["time"] = time_value
+        record["duration_ms"] = int(round(time_value * 1000))
 
     for tag, status in _STATUS_TAGS.items():
         element = testcase.find(tag)

--- a/tests/test_export_pytest_junit.py
+++ b/tests/test_export_pytest_junit.py
@@ -44,6 +44,7 @@ def test_convert_junit_to_jsonl_records_passed_and_failed(tmp_path: Path, xml_co
     assert records == [
         {
             "classname": "sample.TestCase",
+            "duration_ms": 123,
             "name": "test_success",
             "status": "passed",
             "time": 0.123,
@@ -51,6 +52,7 @@ def test_convert_junit_to_jsonl_records_passed_and_failed(tmp_path: Path, xml_co
         {
             "classname": "sample.TestCase",
             "details": "AssertionError",
+            "duration_ms": 456,
             "message": "assertion failed",
             "name": "test_failure",
             "status": "failed",
@@ -86,6 +88,7 @@ def test_convert_junit_to_jsonl_handles_skipped_and_errors(tmp_path: Path) -> No
         {
             "classname": "a.TestCase",
             "details": "Traceback",
+            "duration_ms": 1,
             "message": "boom",
             "name": "test_error",
             "status": "error",
@@ -95,6 +98,7 @@ def test_convert_junit_to_jsonl_handles_skipped_and_errors(tmp_path: Path) -> No
         {
             "classname": "a.TestCase",
             "details": "reason",
+            "duration_ms": 0,
             "message": "not supported",
             "name": "test_skipped",
             "status": "skipped",
@@ -102,6 +106,7 @@ def test_convert_junit_to_jsonl_handles_skipped_and_errors(tmp_path: Path) -> No
         },
         {
             "classname": "a.TestCase",
+            "duration_ms": 10,
             "name": "test_pass",
             "status": "passed",
             "time": 0.01,


### PR DESCRIPTION
## Summary
- ensure junit export records include duration_ms derived from testcase times
- extend export tests to cover the new duration_ms field

## Testing
- pytest tests/test_export_pytest_junit.py

------
https://chatgpt.com/codex/tasks/task_e_68f26f425d008321bc2fc18e25b0f000