### PR TITLE
Fix failure status mapping for pytest JUnit export

### DIFF
--- a/scripts/export_pytest_junit.py
+++ b/scripts/export_pytest_junit.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Iterable, Sequence
 
 _STATUS_TAGS: dict[str, str] = {
-    "failure": "failed",
+    "failure": "fail",
     "error": "error",
     "skipped": "skipped",
 }

--- a/tests/test_scripts_export_pytest_junit.py
+++ b/tests/test_scripts_export_pytest_junit.py
@@ -79,9 +79,33 @@ def test_convert_junit_to_jsonl_records_passed_and_failed(tmp_path: Path, xml_co
             "details": "AssertionError",
             "message": "assertion failed",
             "name": "test_failure",
-            "status": "failed",
+            "status": "fail",
             "duration_ms": 456,
         },
+    ]
+
+
+def test_convert_junit_to_jsonl_sets_fail_status_for_failure(tmp_path: Path) -> None:
+    xml_path = tmp_path / "pytest.xml"
+    output_path = tmp_path / "out.jsonl"
+    write_file(
+        xml_path,
+        """
+        <testcase classname="pkg.TestCase" name="test_failure">
+            <failure />
+        </testcase>
+        """,
+    )
+
+    convert_junit_to_jsonl(xml_path, output_path)
+
+    records = read_json_lines(output_path)
+    assert records == [
+        {
+            "classname": "pkg.TestCase",
+            "name": "test_failure",
+            "status": "fail",
+        }
     ]
 
 


### PR DESCRIPTION
## Summary
- ensure pytest JUnit failure testcases export a "fail" status
- cover the failure status change with a dedicated regression test

## Testing
- pytest tests/test_scripts_export_pytest_junit.py

------
https://chatgpt.com/codex/tasks/task_e_68f271fbf53c8321940c03666581299c