### PR TITLE
Add duration_ms rounding test and convert JUnit time to milliseconds

### DIFF
--- a/scripts/export_pytest_junit.py
+++ b/scripts/export_pytest_junit.py
@@ -56,7 +56,7 @@ def _build_record(testcase: ET.Element) -> dict[str, object]:
         "status": "passed",
     }
     if time_value is not None:
-        record["duration_ms"] = int(time_value * 1000)
+        record["duration_ms"] = int(round(time_value * 1000))
 
     for tag, status in _STATUS_TAGS.items():
         element = testcase.find(tag)

--- a/tests/test_scripts_export_pytest_junit.py
+++ b/tests/test_scripts_export_pytest_junit.py
@@ -44,6 +44,31 @@ def test_convert_junit_to_jsonl_includes_duration_ms(tmp_path: Path) -> None:
     assert "time" not in records[0]
 
 
+def test_convert_junit_to_jsonl_rounds_duration_ms(tmp_path: Path) -> None:
+    xml_path = tmp_path / "pytest.xml"
+    output_path = tmp_path / "out.jsonl"
+    write_file(
+        xml_path,
+        """
+        <testsuite>
+            <testcase classname="pkg.TestCase" name="test_case" time="0.0015" />
+        </testsuite>
+        """,
+    )
+
+    convert_junit_to_jsonl(xml_path, output_path)
+
+    records = read_json_lines(output_path)
+    assert records == [
+        {
+            "classname": "pkg.TestCase",
+            "duration_ms": 2,
+            "name": "test_case",
+            "status": "passed",
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     "xml_content",
     [


### PR DESCRIPTION
## Summary
- add a regression test that verifies JUnit durations are emitted in milliseconds and rounded properly
- round JUnit testcase time values when exporting to JSONL so duration_ms reflects milliseconds accurately

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f271fb970c8321bde4e194a16ddf80