### PR TITLE
Handle error results in analyze

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -36,7 +36,8 @@ def load_results():
             obj = json.loads(stripped)
             tests.append(obj.get("name"))
             durs.append(_normalize_duration(obj.get("duration_ms", 0)))
-            if obj.get("status") == "fail":
+            status = obj.get("status")
+            if isinstance(status, str) and status.lower() in {"fail", "failed", "error"}:
                 fails.append(obj.get("name"))
     return tests, durs, fails
 

--- a/tests/test_scripts_analyze.py
+++ b/tests/test_scripts_analyze.py
@@ -34,6 +34,25 @@ def test_analyze_main_generates_report(tmp_path, monkeypatch):
     assert report_path.exists(), "Report file should be generated"
 
 
+def test_load_results_counts_error_status_as_failure(tmp_path, monkeypatch):
+    log_path = tmp_path / "logs" / "test.jsonl"
+    log_path.parent.mkdir(parents=True)
+
+    records = [
+        {"name": "sample::error_case", "duration_ms": 10, "status": "error"},
+    ]
+
+    with log_path.open("w", encoding="utf-8") as fp:
+        for record in records:
+            fp.write(json.dumps(record) + "\n")
+
+    monkeypatch.setattr(analyze, "LOG", log_path)
+
+    _, _, fails = analyze.load_results()
+
+    assert fails == ["sample::error_case"]
+
+
 def test_analyze_main_handles_blank_lines(tmp_path, monkeypatch):
     log_path = tmp_path / "logs" / "test.jsonl"
     report_path = tmp_path / "reports" / "today.md"


### PR DESCRIPTION
## Summary
- add coverage ensuring analyze.load_results treats error statuses as failures
- extend load_results failure detection to include error and failed statuses

## Testing
- pytest tests/test_scripts_analyze.py

------
https://chatgpt.com/codex/tasks/task_e_68f27e37ce348321a4da85a7cff6c89a