### PR TITLE
Handle skipped tests in analyze report

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -34,11 +34,15 @@ def load_results():
             if not stripped:
                 continue
             obj = json.loads(stripped)
-            tests.append(obj.get("name"))
-            durs.append(_normalize_duration(obj.get("duration_ms", 0)))
             status = obj.get("status")
-            if isinstance(status, str) and status.lower() in {"fail", "failed", "error"}:
-                fails.append(obj.get("name"))
+            status_lower = status.lower() if isinstance(status, str) else ""
+            if status_lower in {"skip", "skipped"}:
+                continue
+            name = obj.get("name")
+            tests.append(name)
+            durs.append(_normalize_duration(obj.get("duration_ms", 0)))
+            if status_lower in {"fail", "failed", "error"}:
+                fails.append(name)
     return tests, durs, fails
 
 def compute_p95(durations: Sequence[object]) -> int:

--- a/tests/test_scripts_analyze.py
+++ b/tests/test_scripts_analyze.py
@@ -154,6 +154,34 @@ def test_analyze_main_handles_empty_log(tmp_path, monkeypatch):
     assert "- Pass rate: 未実行" in report_text
 
 
+def test_analyze_main_treats_skipped_tests_as_unexecuted(tmp_path, monkeypatch):
+    log_path = tmp_path / "logs" / "test.jsonl"
+    report_path = tmp_path / "reports" / "today.md"
+    issue_path = tmp_path / "reports" / "issue_suggestions.md"
+
+    log_path.parent.mkdir(parents=True)
+    report_path.parent.mkdir(parents=True)
+
+    records = [
+        {"name": "sample::test_skip_one", "duration_ms": 5, "status": "skip"},
+        {"name": "sample::test_skip_two", "duration_ms": 10, "status": "skipped"},
+    ]
+
+    with log_path.open("w", encoding="utf-8") as fp:
+        for record in records:
+            fp.write(json.dumps(record) + "\n")
+
+    monkeypatch.setattr(analyze, "LOG", log_path)
+    monkeypatch.setattr(analyze, "REPORT", report_path)
+    monkeypatch.setattr(analyze, "ISSUE_OUT", issue_path)
+
+    analyze.main()
+
+    report_text = report_path.read_text(encoding="utf-8")
+    assert "- Total tests: 0" in report_text
+    assert "- Pass rate: 未実行" in report_text
+
+
 def test_analyze_main_single_record_p95(tmp_path, monkeypatch):
     log_path = tmp_path / "logs" / "test.jsonl"
     report_path = tmp_path / "reports" / "today.md"


### PR DESCRIPTION
## Summary
- add coverage to verify skipped test logs report as not executed
- exclude skipped statuses from test totals and pass rate calculations

## Testing
- pytest tests/test_scripts_analyze.py

------
https://chatgpt.com/codex/tasks/task_e_68f285a418008321bfbbbdf769b433d6