### PR TITLE
Handle case-insensitive OpenAI segments

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -166,9 +166,12 @@ class OpenAICompatProvider(BaseProvider):
             suffix = lowered[1:]
             return bool(suffix) and suffix[0].isdigit()
 
-        has_openai_segment = any(segment == "openai" for segment in segments_for_evaluation)
+        has_openai_segment = any(
+            segment.lower() == "openai" for segment in segments_for_evaluation
+        )
+        last_segment = segments_for_evaluation[-1] if segments_for_evaluation else None
         openai_is_last_segment = bool(
-            segments_for_evaluation and segments_for_evaluation[-1] == "openai"
+            last_segment is not None and last_segment.lower() == "openai"
         )
 
         should_append_v1 = True

--- a/tests/test_providers_openai_compat.py
+++ b/tests/test_providers_openai_compat.py
@@ -160,6 +160,35 @@ def test_openai_compat_preserves_query_parameters(monkeypatch: pytest.MonkeyPatc
     assert response.content == "ok"
 
 
+def test_openai_compat_handles_mixed_case_openai_segment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_def = ProviderDef(
+        name="azure-openai",
+        type="openai",
+        base_url="https://example.openai.azure.com/OpenAI/deployments/foo",
+        model="gpt-4o",
+        auth_env="AZURE_OPENAI_API_KEY",
+        rpm=60,
+        concurrency=1,
+    )
+
+    captured, response = _run_chat_and_capture(
+        provider_def,
+        "AZURE_OPENAI_API_KEY",
+        monkeypatch,
+        expected_url="https://example.openai.azure.com/OpenAI/deployments/foo/chat/completions",
+    )
+
+    assert (
+        captured["url"]
+        == "https://example.openai.azure.com/OpenAI/deployments/foo/chat/completions"
+    )
+    request_json = cast(dict[str, Any], captured["json"])
+    assert request_json["stream"] is False
+    assert response.content == "ok"
+
+
 @pytest.mark.parametrize(
     "base_url",
     [


### PR DESCRIPTION
## Summary
- add coverage for Azure OpenAI base URLs containing mixed-case `OpenAI` segments
- normalize OpenAI segment detection in the OpenAI compatibility provider to use case-insensitive comparisons

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f28fa86f488321aa6697f83abc1a6b