### PR TITLE
Fix OpenAI chat path normalization for v1/chat base URLs

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -140,7 +140,13 @@ class OpenAICompatProvider(BaseProvider):
         has_chat_completions_suffix = bool(
             len(path_segments) >= 2 and path_segments[-2:] == ["chat", "completions"]
         )
-        segments_for_evaluation = path_segments[:-2] if has_chat_completions_suffix else path_segments
+        has_chat_suffix = bool(path_segments and path_segments[-1].lower() == "chat")
+        if has_chat_completions_suffix:
+            segments_for_evaluation = path_segments[:-2]
+        elif has_chat_suffix:
+            segments_for_evaluation = path_segments[:-1]
+        else:
+            segments_for_evaluation = path_segments
         hostname = (parsed.hostname or "").lower()
         azure_compat_suffixes = (
             "openai.azure.com",

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -98,6 +98,16 @@ def test_openai_base_url_uses_chat_completions(monkeypatch: pytest.MonkeyPatch) 
     assert post_calls[0]["url"] == "https://api.openai.com/v1/chat/completions"
 
 
+def test_openai_base_url_including_v1_chat(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    provider = make_provider("https://api.openai.com/v1/chat")
+
+    post_calls, _ = run_chat(provider, monkeypatch)
+
+    assert len(post_calls) == 1
+    assert post_calls[0]["url"] == "https://api.openai.com/v1/chat/completions"
+
+
 def test_openai_chat_response_preserves_finish_reason_and_tool_calls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a regression test ensuring OpenAI base URLs ending with `/v1/chat` invoke the chat completions endpoint once
- adjust the OpenAI provider URL normalization to avoid re-appending existing `chat` or `chat/completions` suffixes

## Testing
- pytest tests/test_providers_openai.py tests/test_providers_openai_compat.py

------
https://chatgpt.com/codex/tasks/task_e_68f2953199008321ab2fa379c77ebcdb