### PR TITLE
Handle chat suffix for OpenAI compat provider

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -142,9 +142,17 @@ class OpenAICompatProvider(BaseProvider):
             len(lowered_segments) >= 2
             and lowered_segments[-2:] == ["chat", "completions"]
         )
+        has_chat_suffix = bool(
+            not has_chat_completions_suffix
+            and lowered_segments
+            and lowered_segments[-1] == "chat"
+        )
         if has_chat_completions_suffix:
             segments_for_evaluation = path_segments[:-2]
             suffix_segments = path_segments[-2:]
+        elif has_chat_suffix:
+            segments_for_evaluation = path_segments[:-1]
+            suffix_segments = [path_segments[-1], "completions"]
         else:
             segments_for_evaluation = path_segments
             suffix_segments = ["chat", "completions"]


### PR DESCRIPTION
## Summary
- add coverage for OpenAI-compatible chat base URLs ending with `/chat`
- adjust the OpenAICompatProvider URL builder to avoid duplicating path segments when a chat suffix is provided

## Testing
- pytest tests/test_providers_openai_compat.py

------
https://chatgpt.com/codex/tasks/task_e_68f29e06b1cc8321a6c2561a17036c75