### PR TITLE
Handle nested testsuites when exporting pytest junit reports

### DIFF
--- a/scripts/export_pytest_junit.py
+++ b/scripts/export_pytest_junit.py
@@ -38,8 +38,20 @@ def _parse_duration_ms(time_str: str | None) -> int | None:
 
 
 def _iter_testcases(root: ET.Element) -> Iterable[ET.Element]:
-    if root.tag == "testcase":
+    tag = root.tag
+
+    if tag == "testcase":
         yield root
+        return
+
+    if tag in {"testsuite", "testsuites"}:
+        for child in root:
+            if child.tag == "testcase":
+                yield child
+            elif child.tag in {"testsuite", "testsuites"}:
+                yield from _iter_testcases(child)
+            else:
+                yield from _iter_testcases(child)
         return
 
     for child in root:


### PR DESCRIPTION
## Summary
- add coverage to ensure exporting handles nested <testsuite> elements produced by pytest
- recurse through nested testsuite/testsuites nodes when collecting testcase elements

## Testing
- pytest tests/test_scripts_export_pytest_junit.py

------
https://chatgpt.com/codex/tasks/task_e_68f29e0764a88321a2ca6da76d07dec8