### PR TITLE
Ensure governance gate exits on priority validation failure

### DIFF
--- a/workflow-cookbook-main/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook-main/tools/ci/check_governance_gate.py
@@ -112,7 +112,9 @@ def main() -> int:
         print("GITHUB_EVENT_PATH is not set", file=sys.stderr)
         return 1
     body = read_event_body(Path(event_path_value))
-    validate_priority_score(body)
+    if not validate_priority_score(body):
+        print("Priority score validation failed", file=sys.stderr)
+        return 1
 
     return 0
 


### PR DESCRIPTION
## Summary
- extend governance gate tests to cover main() exit codes for priority validation results
- make main() surface priority score validation failures via stderr and non-zero exit

## Testing
- pytest workflow-cookbook-main/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68f2aec01dd083218e171644c452eaa6