### PR TITLE
Add validation for governance priority score field

### DIFF
--- a/tests/test_ci_check_governance_gate.py
+++ b/tests/test_ci_check_governance_gate.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "workflow-cookbook-main"))
+
+from tools.ci.check_governance_gate import validate_priority_score
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        None,
+        "",
+        "本文には Priority Score がありません",
+    ],
+)
+def test_validate_priority_score_returns_false_when_section_missing(body: str | None) -> None:
+    assert validate_priority_score(body) is False
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Priority Score: 3",
+        "Priority Score: / 根拠なし",
+        "Priority Score: abc / 理由",
+        "Priority Score: 0 / 理由",
+        "Priority Score: 6 / 理由",
+        "Priority Score: 2 / <!-- placeholder -->",
+    ],
+)
+def test_validate_priority_score_returns_false_when_format_invalid(body: str) -> None:
+    assert validate_priority_score(body) is False
+
+
+def test_validate_priority_score_returns_true_when_format_valid() -> None:
+    body = """
+    ## Summary
+    - 変更内容
+
+    Priority Score: 4 / prioritization.yaml#phase2 に基づき対応
+    """.strip()
+
+    assert validate_priority_score(body) is True

--- a/workflow-cookbook-main/tests/test_check_governance_gate.py
+++ b/workflow-cookbook-main/tests/test_check_governance_gate.py
@@ -35,6 +35,15 @@ def test_find_forbidden_matches(changed_paths, patterns, expected):
     [
         "Priority Score: 5 / 安全性強化",
         "Priority Score: 1 / 即応性向上",
+    ],
+)
+def test_validate_priority_score_accepts_valid_format(body):
+    assert validate_priority_score(body) is True
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
         "Priority Score: 3",
         "Priority Score: / 理由",
         "Priority Score: abc / 理由",
@@ -44,8 +53,8 @@ def test_find_forbidden_matches(changed_paths, patterns, expected):
         None,
     ],
 )
-def test_validate_priority_score_is_now_noop(body):
-    assert validate_priority_score(body) is True
+def test_validate_priority_score_rejects_invalid_format(body):
+    assert validate_priority_score(body) is False
 
 
 def test_load_forbidden_patterns(tmp_path):

--- a/workflow-cookbook-main/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook-main/tools/ci/check_governance_gate.py
@@ -86,7 +86,36 @@ def read_event_body(event_path: Path) -> str | None:
 
 
 def validate_priority_score(body: str | None) -> bool:
-    return True
+    if body is None:
+        return False
+
+    header = "Priority Score:"
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line.startswith(header):
+            continue
+
+        remainder = line[len(header) :].strip()
+        if not remainder or remainder.startswith("<!--"):
+            continue
+
+        if "/" not in remainder:
+            continue
+
+        score_text, reason = (part.strip() for part in remainder.split("/", 1))
+        if not score_text.isdigit():
+            continue
+
+        score = int(score_text)
+        if score < 1 or score > 5:
+            continue
+
+        if not reason or reason.startswith("<!--"):
+            continue
+
+        return True
+
+    return False
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- add repository tests to ensure the governance gate fails when the priority score is missing or malformed
- implement the priority score parser used by the governance gate script
- update cookbook tests to assert the new validation behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f2b199305c8321bcb887d93790dd00