### PR TITLE
Handle default namespace in pytest JUnit exporter

### DIFF
--- a/scripts/export_pytest_junit.py
+++ b/scripts/export_pytest_junit.py
@@ -14,6 +14,12 @@ _STATUS_TAGS: dict[str, str] = {
 }
 
 
+def _strip_namespace(tag: str) -> str:
+    if tag.startswith("{"):
+        return tag.split("}", 1)[1]
+    return tag
+
+
 def convert_junit_to_jsonl(input_path: Path, output_path: Path) -> None:
     tree = ET.parse(input_path)
     root = tree.getroot()
@@ -38,20 +44,10 @@ def _parse_duration_ms(time_str: str | None) -> int | None:
 
 
 def _iter_testcases(root: ET.Element) -> Iterable[ET.Element]:
-    tag = root.tag
+    tag = _strip_namespace(root.tag)
 
     if tag == "testcase":
         yield root
-        return
-
-    if tag in {"testsuite", "testsuites"}:
-        for child in root:
-            if child.tag == "testcase":
-                yield child
-            elif child.tag in {"testsuite", "testsuites"}:
-                yield from _iter_testcases(child)
-            else:
-                yield from _iter_testcases(child)
         return
 
     for child in root:

--- a/tests/test_scripts_export_pytest_junit.py
+++ b/tests/test_scripts_export_pytest_junit.py
@@ -232,6 +232,38 @@ def test_convert_junit_to_jsonl_handles_nested_testsuites(tmp_path: Path) -> Non
     ]
 
 
+def test_convert_junit_to_jsonl_handles_default_namespace(tmp_path: Path) -> None:
+    xml_path = tmp_path / "pytest.xml"
+    output_path = tmp_path / "out.jsonl"
+    write_file(
+        xml_path,
+        """
+        <testsuite xmlns="urn:pytest">
+            <testcase classname="pkg.TestCase" name="test_one" time="0.100" />
+            <testcase classname="pkg.TestCase" name="test_two" time="0.200" />
+        </testsuite>
+        """,
+    )
+
+    convert_junit_to_jsonl(xml_path, output_path)
+
+    records = read_json_lines(output_path)
+    assert records == [
+        {
+            "classname": "pkg.TestCase",
+            "duration_ms": 100,
+            "name": "test_one",
+            "status": "passed",
+        },
+        {
+            "classname": "pkg.TestCase",
+            "duration_ms": 200,
+            "name": "test_two",
+            "status": "passed",
+        },
+    ]
+
+
 def test_convert_junit_to_jsonl_normalizes_error_status(tmp_path: Path) -> None:
     xml_path = tmp_path / "pytest.xml"
     output_path = tmp_path / "out.jsonl"


### PR DESCRIPTION
## Summary
- add regression coverage for pytest JUnit XML files that declare a default namespace
- strip XML namespaces before classifying nodes so all testcase elements are exported

## Testing
- pytest tests/test_scripts_export_pytest_junit.py

------
https://chatgpt.com/codex/tasks/task_e_68f2b738dbb883218113ac2f07a2b46f