### PR TITLE
Handle namespaced testcase statuses

### DIFF
--- a/scripts/export_pytest_junit.py
+++ b/scripts/export_pytest_junit.py
@@ -78,7 +78,10 @@ def _build_record(testcase: ET.Element) -> dict[str, object]:
         record["duration_ms"] = duration_ms
 
     for tag, status in _STATUS_TAGS.items():
-        element = testcase.find(tag)
+        element = next(
+            (child for child in testcase if _strip_namespace(child.tag) == tag),
+            None,
+        )
         if element is not None:
             record["status"] = status
             message = element.attrib.get("message")


### PR DESCRIPTION
## Summary
- add junit fixture with default namespace that includes failure and skipped cases
- strip namespaces from testcase child tags before evaluating pytest status

## Testing
- pytest tests/test_scripts_export_pytest_junit.py

------
https://chatgpt.com/codex/tasks/task_e_68f2bf5366a483218b6a003647f4de47