### PR TITLE
Handle globstar matches for governance gate

### DIFF
--- a/workflow-cookbook-main/tests/test_check_governance_gate.py
+++ b/workflow-cookbook-main/tests/test_check_governance_gate.py
@@ -17,6 +17,11 @@ from tools.ci.check_governance_gate import (
     "changed_paths, patterns, expected",
     [
         ("""core/schema/model.yaml\ndocs/guide.md""".splitlines(), ["/core/schema/**"], ["core/schema/model.yaml"]),
+        (
+            """core/schema/nested/file.yaml""".splitlines(),
+            ["/core/schema/**"],
+            ["core/schema/nested/file.yaml"],
+        ),
         ("""docs/readme.md\nops/runbook.md""".splitlines(), ["/core/schema/**"], []),
         (
             """auth/service.py\ncore/schema/definitions.yml""".splitlines(),


### PR DESCRIPTION
## Summary
- add a regression test that ensures nested core schema files are detected by governance patterns
- update forbidden path detection to interpret globstar patterns across directories

## Testing
- pytest workflow-cookbook-main/tests/test_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68f2bf5345f08321b9e669d2222c29a9