### PR TITLE
Handle namespaced JUnit statuses

### DIFF
--- a/scripts/export_pytest_junit.py
+++ b/scripts/export_pytest_junit.py
@@ -77,23 +77,23 @@ def _build_record(testcase: ET.Element) -> dict[str, object]:
     if duration_ms is not None:
         record["duration_ms"] = duration_ms
 
-    for tag, status in _STATUS_TAGS.items():
-        element = next(
-            (child for child in testcase if _strip_namespace(child.tag) == tag),
-            None,
-        )
-        if element is not None:
-            record["status"] = status
-            message = element.attrib.get("message")
-            if message:
-                record["message"] = message
-            text = (element.text or "").strip()
-            if text:
-                record["details"] = text
-            error_type = element.attrib.get("type")
-            if error_type:
-                record["type"] = error_type
-            break
+    for child in testcase:
+        tag = _strip_namespace(child.tag)
+        status = _STATUS_TAGS.get(tag)
+        if status is None:
+            continue
+
+        record["status"] = status
+        message = child.attrib.get("message")
+        if message:
+            record["message"] = message
+        text = (child.text or "").strip()
+        if text:
+            record["details"] = text
+        error_type = child.attrib.get("type")
+        if error_type:
+            record["type"] = error_type
+        break
 
     return record
 

--- a/tests/test_scripts_export_pytest_junit.py
+++ b/tests/test_scripts_export_pytest_junit.py
@@ -327,6 +327,46 @@ def test_convert_junit_to_jsonl_handles_default_namespace_fail_and_skip(
     ]
 
 
+def test_convert_junit_to_jsonl_handles_prefixed_namespace_fail_and_skip(
+    tmp_path: Path,
+) -> None:
+    xml_path = tmp_path / "pytest.xml"
+    output_path = tmp_path / "out.jsonl"
+    write_file(
+        xml_path,
+        """
+        <testsuite xmlns:pytest="urn:pytest">
+            <testcase classname="pkg.TestCase" name="test_failure">
+                <pytest:failure message="boom">details</pytest:failure>
+            </testcase>
+            <testcase classname="pkg.TestCase" name="test_skipped">
+                <pytest:skipped message="later">because</pytest:skipped>
+            </testcase>
+        </testsuite>
+        """,
+    )
+
+    convert_junit_to_jsonl(xml_path, output_path)
+
+    records = read_json_lines(output_path)
+    assert records == [
+        {
+            "classname": "pkg.TestCase",
+            "details": "details",
+            "message": "boom",
+            "name": "test_failure",
+            "status": "fail",
+        },
+        {
+            "classname": "pkg.TestCase",
+            "details": "because",
+            "message": "later",
+            "name": "test_skipped",
+            "status": "skip",
+        },
+    ]
+
+
 def test_convert_junit_to_jsonl_normalizes_error_status(tmp_path: Path) -> None:
     xml_path = tmp_path / "pytest.xml"
     output_path = tmp_path / "out.jsonl"


### PR DESCRIPTION
## Summary
- add a regression test covering prefixed namespace failure and skipped elements in the JUnit exporter
- iterate testcase children with namespace stripping so namespaced status elements are detected

## Testing
- pytest tests/test_scripts_export_pytest_junit.py

------
https://chatgpt.com/codex/tasks/task_e_68f30b4edc4c8321bcd16ce07653803c