### PR TITLE
Add JSON response format support for Ollama provider

### DIFF
--- a/src/orch/providers.py
+++ b/src/orch/providers.py
@@ -680,6 +680,14 @@ class OllamaProvider(BaseProvider):
             "stream": False,
             "options": {"temperature": temperature, "num_predict": max_tokens},
         }
+        if response_format is not None:
+            format_type = response_format.get("type")
+            if format_type == "json_object":
+                payload["format"] = "json"
+            else:
+                raise ValueError(
+                    "OllamaProvider only supports response_format type 'json_object'."
+                )
         cleaned_options = {
             key: value
             for key, value in extra_options.items()

--- a/tests/test_providers_ollama.py
+++ b/tests/test_providers_ollama.py
@@ -1,0 +1,79 @@
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.orch.providers import OllamaProvider  # noqa: E402
+from src.orch.router import ProviderDef  # noqa: E402
+
+
+class _DummyResponse:
+    status_code = 200
+
+    @staticmethod
+    def json() -> dict[str, Any]:
+        return {"message": {"content": "ok"}, "done": True}
+
+    @staticmethod
+    def raise_for_status() -> None:
+        return None
+
+
+def _make_provider() -> OllamaProvider:
+    provider_def = ProviderDef(
+        name="ollama",
+        type="ollama",
+        base_url="http://localhost:11434",
+        model="llama3",
+        auth_env=None,
+        rpm=120,
+        concurrency=1,
+    )
+    return OllamaProvider(provider_def)
+
+
+def test_ollama_sets_format_json_for_json_object(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _make_provider()
+    post_calls: list[dict[str, Any]] = []
+
+    class _DummyAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            _ = args
+            _ = kwargs
+
+        async def __aenter__(self) -> "_DummyAsyncClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: Any,
+        ) -> None:
+            return None
+
+        async def post(self, url: str, *, json: Any | None = None, **kwargs: Any) -> _DummyResponse:
+            post_calls.append({"url": url, "json": json, "kwargs": kwargs})
+            return _DummyResponse()
+
+    monkeypatch.setattr("httpx.AsyncClient", _DummyAsyncClient)
+
+    async def invoke() -> None:
+        await provider.chat(
+            model="llama3",
+            messages=[{"role": "user", "content": "ping"}],
+            response_format={"type": "json_object"},
+        )
+
+    asyncio.run(invoke())
+
+    assert post_calls
+    payload = post_calls[0]["json"]
+    assert isinstance(payload, dict)
+    assert payload.get("format") == "json"


### PR DESCRIPTION
## Summary
- add coverage ensuring Ollama chat requests include the json format flag when a JSON response is requested
- set the Ollama payload format field when response_format requires a JSON object and reject unsupported types

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f3110ffc588321b9706a3d20cbd280