### PR TITLE
Add test for Ollama top_p option propagation

### DIFF
--- a/tests/test_providers_ollama.py
+++ b/tests/test_providers_ollama.py
@@ -1,11 +1,17 @@
 import asyncio
+import sys
+from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
 
-from src.orch.providers import OllamaProvider
-from src.orch.router import ProviderDef
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.orch.providers import OllamaProvider  # noqa: E402
+from src.orch.router import ProviderDef  # noqa: E402
 
 
 def make_provider(base_url: str = "http://localhost:11434") -> OllamaProvider:


### PR DESCRIPTION
## Summary
- ensure the Ollama provider chat payload reuses the options dictionary and applies the top_p override when provided
- add a pytest covering that a top_p argument propagates into the outgoing JSON, including test setup for module imports

## Testing
- pytest tests/test_providers_ollama.py

------
https://chatgpt.com/codex/tasks/task_e_68f3155129248321adb18ea902d97bf6