### PR TITLE
Fix governance gate pattern normalization

### DIFF
--- a/tests/test_ci_check_governance_gate.py
+++ b/tests/test_ci_check_governance_gate.py
@@ -8,7 +8,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "workflow-cookbook-main"))
 
-from tools.ci.check_governance_gate import validate_priority_score
+from tools.ci.check_governance_gate import find_forbidden_matches, validate_priority_score
 
 
 @pytest.mark.parametrize(
@@ -47,3 +47,10 @@ def test_validate_priority_score_returns_true_when_format_valid() -> None:
     """.strip()
 
     assert validate_priority_score(body) is True
+
+
+def test_find_forbidden_matches_supports_leading_dot_slash_patterns() -> None:
+    paths = ["docs/foo.md"]
+    patterns = ["./docs/**"]
+
+    assert find_forbidden_matches(paths, patterns) == ["docs/foo.md"]

--- a/workflow-cookbook-main/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook-main/tools/ci/check_governance_gate.py
@@ -58,13 +58,24 @@ def get_changed_paths(refspec: str) -> List[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
+def _normalize_forbidden_value(value: str) -> str:
+    value = value.lstrip("/")
+    while value.startswith("./") or value.startswith("../"):
+        if value.startswith("./"):
+            value = value[2:]
+        else:
+            value = value[3:]
+        value = value.lstrip("/")
+    return value
+
+
 def find_forbidden_matches(paths: Iterable[str], patterns: Sequence[str]) -> List[str]:
     matches: List[str] = []
     for path in paths:
-        normalized_path = path.lstrip("./")
+        normalized_path = _normalize_forbidden_value(path)
         path_object = Path(normalized_path)
         for pattern in patterns:
-            normalized_pattern = pattern.lstrip("/")
+            normalized_pattern = _normalize_forbidden_value(pattern)
             if path_object.match(normalized_pattern):
                 matches.append(normalized_path)
                 break


### PR DESCRIPTION
## Summary
- add regression coverage to ensure leading "./" patterns catch documentation paths
- normalize forbidden path and pattern handling before applying match/is_relative_to

## Testing
- pytest tests/test_ci_check_governance_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68f322b473b083219b629a689a720aa4