### PR TITLE
Fix governance gate pattern normalization for relative docs paths

### DIFF
--- a/workflow-cookbook-main/tests/test_check_governance_gate.py
+++ b/workflow-cookbook-main/tests/test_check_governance_gate.py
@@ -22,6 +22,11 @@ from tools.ci.check_governance_gate import (
             ["/core/schema/**"],
             ["core/schema/nested/file.yaml"],
         ),
+        (
+            """docs/sub/file.md""".splitlines(),
+            ["./docs/**"],
+            ["docs/sub/file.md"],
+        ),
         ("""docs/readme.md\nops/runbook.md""".splitlines(), ["/core/schema/**"], []),
         (
             """auth/service.py\ncore/schema/definitions.yml""".splitlines(),


### PR DESCRIPTION
## Summary
- add a regression test so a ./docs/** policy entry flags docs/sub/file.md
- normalize forbidden patterns with PurePosixPath so Path.match handles leading ./ and ../ correctly
- skip empty patterns to avoid ValueError during matching

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f3297cee508321a9781a19bee1a58f