### PR TITLE
Handle inline comments in governance gate patterns

### DIFF
--- a/workflow-cookbook-main/tests/test_check_governance_gate.py
+++ b/workflow-cookbook-main/tests/test_check_governance_gate.py
@@ -83,6 +83,31 @@ self_modification:
     assert load_forbidden_patterns(policy) == ["core/schema/**", "auth/**"]
 
 
+@pytest.mark.parametrize(
+    "item, expected",
+    [
+        ("- /infra/**  # コメント", ["infra/**"]),
+        ("- '/secure/**'  # コメント", ["secure/**"]),
+        ("- \"/quoted/**\"  # コメント", ["quoted/**"]),
+        ("- \"#literal\"  # コメント", ["#literal"]),
+        ("- # コメントのみ", []),
+    ],
+)
+def test_load_forbidden_patterns_supports_inline_comments(tmp_path, item, expected):
+    policy = tmp_path / "policy.yaml"
+    policy.write_text(
+        "\n".join(
+            [
+                "self_modification:",
+                "  forbidden_paths:",
+                f"    {item}",
+            ]
+        )
+    )
+
+    assert load_forbidden_patterns(policy) == expected
+
+
 def test_main_returns_error_when_priority_invalid(monkeypatch, tmp_path, capsys):
     event_file = tmp_path / "event.json"
     event_file.write_text("""{"pull_request": {"body": "invalid"}}""")

--- a/workflow-cookbook-main/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook-main/tools/ci/check_governance_gate.py
@@ -35,6 +35,18 @@ def load_forbidden_patterns(policy_path: Path) -> List[str]:
 
         if in_forbidden_paths and stripped_line.startswith("- "):
             value = stripped_line[2:].strip()
+            comment_stripped: list[str] = []
+            in_single_quote = False
+            in_double_quote = False
+            for character in value:
+                if character == "'" and not in_double_quote:
+                    in_single_quote = not in_single_quote
+                elif character == '"' and not in_single_quote:
+                    in_double_quote = not in_double_quote
+                elif character == "#" and not in_single_quote and not in_double_quote:
+                    break
+                comment_stripped.append(character)
+            value = "".join(comment_stripped).strip()
             if len(value) >= 2 and value[0] in {'"', "'"} and value[-1] == value[0]:
                 value = value[1:-1]
             if value:


### PR DESCRIPTION
## Summary
- add coverage ensuring forbidden_paths entries handle inline comments
- strip unquoted inline comments when loading governance forbidden patterns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f332931afc83218fe5ffef99e84663