### PR TITLE
Add direct _strip_namespace test and document helper

### DIFF
--- a/scripts/export_pytest_junit.py
+++ b/scripts/export_pytest_junit.py
@@ -15,9 +15,10 @@ _STATUS_TAGS: dict[str, str] = {
 
 
 def _strip_namespace(tag: str) -> str:
-    if "}" in tag:
-        return tag.split("}", 1)[1]
-    return tag
+    """Return the local tag name without any XML namespace prefix."""
+    if "}" not in tag:
+        return tag
+    return tag.split("}", 1)[1]
 
 
 def convert_junit_to_jsonl(input_path: Path, output_path: Path) -> None:

--- a/tests/test_scripts_export_pytest_junit.py
+++ b/tests/test_scripts_export_pytest_junit.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scripts.export_pytest_junit import convert_junit_to_jsonl
+from scripts.export_pytest_junit import _strip_namespace, convert_junit_to_jsonl
 
 
 def write_file(path: Path, content: str) -> None:
@@ -16,6 +16,17 @@ def write_file(path: Path, content: str) -> None:
 def read_json_lines(path: Path) -> list[dict[str, object]]:
     with path.open(encoding="utf-8") as handle:
         return [json.loads(line) for line in handle]
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("{http://example.com}testcase", "testcase"),
+        ("testcase", "testcase"),
+    ],
+)
+def test_strip_namespace_handles_prefixed_and_plain_tags(tag: str, expected: str) -> None:
+    assert _strip_namespace(tag) == expected
 
 
 def test_convert_junit_to_jsonl_handles_large_suites(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add coverage for `_strip_namespace` to confirm namespaced tags are normalized correctly
- document the shared `_strip_namespace` helper that all parsing utilities call

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f3329290848321ac273dae7da3bce9