### PR TITLE
Handle inline comments in governance forbidden paths

### DIFF
--- a/workflow-cookbook-main/tests/test_check_governance_gate.py
+++ b/workflow-cookbook-main/tests/test_check_governance_gate.py
@@ -108,6 +108,21 @@ def test_load_forbidden_patterns_supports_inline_comments(tmp_path, item, expect
     assert load_forbidden_patterns(policy) == expected
 
 
+def test_load_forbidden_patterns_preserves_hash_within_quotes(tmp_path):
+    policy = tmp_path / "policy.yaml"
+    policy.write_text(
+        "\n".join(
+            [
+                "self_modification:",
+                "  forbidden_paths:",
+                "    - '/path#literal'  # trailing comment",
+            ]
+        )
+    )
+
+    assert load_forbidden_patterns(policy) == ["path#literal"]
+
+
 def test_main_returns_error_when_priority_invalid(monkeypatch, tmp_path, capsys):
     event_file = tmp_path / "event.json"
     event_file.write_text("""{"pull_request": {"body": "invalid"}}""")

--- a/workflow-cookbook-main/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook-main/tools/ci/check_governance_gate.py
@@ -8,6 +8,21 @@ from pathlib import Path, PurePosixPath
 from typing import Iterable, List, Sequence
 
 
+def _strip_inline_comment(value: str) -> str:
+    comment_stripped: list[str] = []
+    in_single_quote = False
+    in_double_quote = False
+    for character in value:
+        if character == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+        elif character == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+        elif character == "#" and not in_single_quote and not in_double_quote:
+            break
+        comment_stripped.append(character)
+    return "".join(comment_stripped).strip()
+
+
 def load_forbidden_patterns(policy_path: Path) -> List[str]:
     patterns: List[str] = []
     in_self_modification = False
@@ -35,18 +50,7 @@ def load_forbidden_patterns(policy_path: Path) -> List[str]:
 
         if in_forbidden_paths and stripped_line.startswith("- "):
             value = stripped_line[2:].strip()
-            comment_stripped: list[str] = []
-            in_single_quote = False
-            in_double_quote = False
-            for character in value:
-                if character == "'" and not in_double_quote:
-                    in_single_quote = not in_single_quote
-                elif character == '"' and not in_single_quote:
-                    in_double_quote = not in_double_quote
-                elif character == "#" and not in_single_quote and not in_double_quote:
-                    break
-                comment_stripped.append(character)
-            value = "".join(comment_stripped).strip()
+            value = _strip_inline_comment(value)
             if len(value) >= 2 and value[0] in {'"', "'"} and value[-1] == value[0]:
                 value = value[1:-1]
             if value:


### PR DESCRIPTION
## Summary
- add a helper that removes inline comments from forbidden path entries while respecting quoted hashes
- extend governance gate tests to cover inline comments that include literal hash characters inside quotes

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f33d4d6bc88321ace076a32cd072e3