### PR TITLE
Ensure analyze log reading handles UTF-8 input

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -32,7 +32,7 @@ def load_results():
     tests, durs, fails = [], [], []
     if not LOG.exists():
         return tests, durs, fails
-    with LOG.open() as f:
+    with LOG.open(encoding="utf-8") as f:
         for line in f:
             stripped = line.strip()
             if not stripped:

--- a/tests/test_scripts_analyze.py
+++ b/tests/test_scripts_analyze.py
@@ -79,6 +79,27 @@ def test_load_results_counts_multiple_failure_statuses(tmp_path, monkeypatch):
     ]
 
 
+def test_load_results_handles_utf8_content(tmp_path, monkeypatch):
+    log_path = tmp_path / "logs" / "test.jsonl"
+    log_path.parent.mkdir(parents=True)
+
+    records = [
+        {"name": "サンプル::成功", "duration_ms": 12, "status": "pass"},
+        {"name": "サンプル::失敗", "duration_ms": 34, "status": "fail"},
+    ]
+
+    with log_path.open("w", encoding="utf-8") as fp:
+        for record in records:
+            fp.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    monkeypatch.setattr(analyze, "LOG", log_path)
+
+    tests, _, fails = analyze.load_results()
+
+    assert tests == ["サンプル::成功", "サンプル::失敗"]
+    assert fails == ["サンプル::失敗"]
+
+
 def test_analyze_main_handles_blank_lines(tmp_path, monkeypatch):
     log_path = tmp_path / "logs" / "test.jsonl"
     report_path = tmp_path / "reports" / "today.md"


### PR DESCRIPTION
## Summary
- open analyze log files with explicit UTF-8 encoding
- add regression test covering UTF-8 JSONL input for load_results

## Testing
- pytest tests/test_scripts_analyze.py

------
https://chatgpt.com/codex/tasks/task_e_68f33d4f6d288321a58dc9aa1eb09fbe