### PR TITLE
Skip missing durations when aggregating logs

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -51,7 +51,10 @@ def load_results():
             if not status_lower or status_lower in _SKIPPED_STATUSES:
                 continue
             tests.append(obj.get("name"))
-            durs.append(_normalize_duration(obj.get("duration_ms", 0)))
+            if "duration_ms" in obj:
+                duration_value = obj.get("duration_ms")
+                if duration_value is not None:
+                    durs.append(_normalize_duration(duration_value))
             if any(status_lower.startswith(prefix) for prefix in _FAIL_STATUS_PREFIXES):
                 fails.append(obj.get("name"))
     return tests, durs, fails

--- a/tests/test_scripts_analyze.py
+++ b/tests/test_scripts_analyze.py
@@ -79,6 +79,27 @@ def test_load_results_counts_multiple_failure_statuses(tmp_path, monkeypatch):
     ]
 
 
+def test_load_results_ignores_missing_duration_records(tmp_path, monkeypatch):
+    log_path = tmp_path / "logs" / "test.jsonl"
+    log_path.parent.mkdir(parents=True)
+
+    records = [
+        {"name": "sample::no_duration", "status": "pass"},
+        {"name": "sample::none_duration", "duration_ms": None, "status": "pass"},
+        {"name": "sample::with_duration", "duration_ms": 15, "status": "pass"},
+    ]
+
+    with log_path.open("w", encoding="utf-8") as fp:
+        for record in records:
+            fp.write(json.dumps(record) + "\n")
+
+    monkeypatch.setattr(analyze, "LOG", log_path)
+
+    _, durations, _ = analyze.load_results()
+
+    assert durations == [15]
+
+
 def test_load_results_handles_utf8_content(tmp_path, monkeypatch):
     log_path = tmp_path / "logs" / "test.jsonl"
     log_path.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- add a regression test verifying duration aggregation skips records without duration_ms
- update load_results to ignore missing or null duration_ms values when building duration lists

## Testing
- pytest tests/test_scripts_analyze.py

------
https://chatgpt.com/codex/tasks/task_e_68f3430df5088321b404523169938f8a