### PR TITLE
Ensure asyncio import is prioritized in Ollama provider tests

### DIFF
--- a/tests/test_providers_ollama.py
+++ b/tests/test_providers_ollama.py
@@ -1,6 +1,6 @@
 import asyncio
-import sys
 from pathlib import Path
+import sys
 from typing import Any
 
 import httpx


### PR DESCRIPTION
## Summary
- reorder the standard-library imports in `tests/test_providers_ollama.py` so `asyncio` is clearly present at the top

## Testing
- pytest tests/test_providers_ollama.py

------
https://chatgpt.com/codex/tasks/task_e_68f3548f5fdc832193306706f717779b