### PR TITLE
Ensure health test imports include stdlib modules

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,8 +1,8 @@
 import importlib
 import os
 import sys
-import textwrap
 from pathlib import Path
+import textwrap
 
 import pytest
 from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- keep the standard-library imports grouped at the top of `tests/test_health.py`

## Testing
- pytest tests/test_health.py

------
https://chatgpt.com/codex/tasks/task_e_68f35490dac08321b89526c726187551