### PR TITLE
docs: update streaming spec and routing guidance

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -5,7 +5,7 @@
 - 200 OK: `{ "status":"ok", "providers": ["frontier_primary", "..."] }`
 
 ### 1.2 POST /v1/chat/completions
-- 互換: OpenAI Chat Completions（非stream）。
+- 互換: OpenAI Chat Completions（`stream:true` を推奨）。
 - 入力（抜粋）:
   ```json
   {
@@ -13,21 +13,36 @@
     "messages": [{"role":"user","content":"hi"}],
     "temperature": 0.2,
     "max_tokens": 2048,
-    "stream": false
+    "stream": true
+  }
+  ```
+- 観測用レスポンスヘッダ:
+  - `x-orch-request-id`: オーケストレータ内部リクエストID。
+  - `x-orch-provider`: 実際に利用されたプロバイダ名。
+  - `x-orch-fallback-attempts`: フォールバック実施回数。
+- ストリームレスポンス: `Content-Type: text/event-stream`。SSEイベント例:
+  ```
+  event: chat.completion.chunk
+  data: {"id":"chatcmpl-...","object":"chat.completion.chunk","created":1739560000,"model":"<effective model>","choices":[{"index":0,"delta":{"role":"assistant","content":"..."},"finish_reason":null}]}
+
+  event: telemetry.usage
+  data: {"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}
+
+  event: done
+  data: {}
+  ```
+- 非stream時（`stream:false`）はOpenAI互換JSONを単発返却。
+- エラー時の例:
+  ```json
+  {
+    "error": {
+      "message": "rate limited",
+      "type": "rate_limit",
+      "retry_after": 2.5
+    }
   }
   ```
 - ヘッダ: `x-orch-task-kind: PLAN|CRITIQUE|CODE|SUMMARY|BULK|DEFAULT`
-- 出力（例）: OpenAI互換
-  ```json
-  {
-    "id":"chatcmpl-...",
-    "object":"chat.completion",
-    "created": 1739560000,
-    "model":"<effective model>",
-    "choices":[{"index":0,"message":{"role":"assistant","content":"..."},"finish_reason":"stop"}],
-    "usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}
-  }
-  ```
 
 ## 2. コンフィグ
 ### 2.1 providers.toml
@@ -46,6 +61,11 @@
   - anthropic: `/v1/messages` にマッピング。
   - ollama: `POST /api/chat` にマッピング。
   - dummy: ローカルエコーバック。
+- 重み付き／優先度付きルーティング: `weight = 2` などの数値で均等割り込み、`priority = 0` で優先度ソート。
+- スティッキー割当: `sticky_key = "account_id"` を指定すると同一キーでプロバイダ固定。
+- サーキットブレーカ: `circuit_breaker = { failure_rate = 0.5, window = 30, cooldown = 120 }` を追加し、閾値超過で一定時間停止。
+- CORS/APIキー: `allow_origins = ["https://example.com"]`, `api_keys = ["...hash..."]` を設定。
+- ホットリロード: ファイル保存→`orchctl reload providers` 実行で無停止再読込。
 
 ### 2.2 router.yaml
 - 例:
@@ -58,9 +78,18 @@
     DEFAULT:  { primary: hosted_fast,       fallback: [frontier_primary, local_7b] }
   ```
 - 解決手順: ヘッダ値→該当ルート、無ければ DEFAULT。primary→順に fallback。
+- 追加設定例:
+  - `weights`: `{ hosted_fast: 3, frontier_primary: 1 }` で加重ラウンドロビン。
+  - `priority`: `[hosted_fast, frontier_primary, local_7b]` で優先順を固定。
+  - `sticky`: `header: x-user-id, ttl: 3600` で同一ヘッダ値の間はプロバイダ固定。
+  - `circuit_breaker_ref`: providers.toml で定義したブレーカを参照。
+  - `cors`: `{ allow_origins: ["*"], allow_headers: ["content-type", "authorization"] }`。
+  - `api_keys`: `[{ id: "ops", value_env: "ORCH_API_KEY_OPS" }]`。
+  - ホットリロード手順: 変更→`orchctl reload router`→ヘルス確認。
 
 ## 3. レート制御と並列
-- TokenBucket (per-provider): rpm で1分窓リフィル。残量0なら窓切替まで待機。
+- Token Per Minute (TPM) スライディングウィンドウ: 各プロバイダの `tpm` 設定で制御。ウィンドウ長1分、到着時刻ベースで残量算出。
+- RPMは補助制限として従来のTokenBucket互換を維持。
 - Semaphore (per-provider): concurrency を超える同時実行を阻止。
 
 ## 4. リトライ/フォールバック
@@ -70,23 +99,11 @@
   { "error": { "message": "<last error>" } }
   ```
 
-## 5. メトリクス（JSONL）
-- 出力: `metrics/requests-YYYYMMDD.jsonl`
-- レコード例:
-  ```json
-  {
-    "ts": 1739560000.123,
-    "task": "CODE",
-    "provider": "hosted_fast",
-    "model": "llama-3.1-8b-instruct",
-    "latency_ms": 245,
-    "ok": true,
-    "status": 200,
-    "retries": 0,
-    "usage_prompt": 0,
-    "usage_completion": 0
-  }
-  ```
+## 5. メトリクス
+- Prometheusエクスポート: `orch_requests_total`, `orch_request_latency_seconds`, `orch_tokens_total` など。
+- OpenTelemetryトレース: span属性に `orch.provider`, `orch.route`, `usage.prompt_tokens`, `usage.completion_tokens`。
+- JSONLログ: `metrics/requests-YYYYMMDD.jsonl` は従来通り出力し、構造は互換。
+- 両者併存ポリシー: JSONLはバッチ解析、Prometheus/OTelはリアルタイム監視を担当。停止不可の場合はJSONLのみ継続利用。
 
 ## 6. 環境変数
 - ORCH_CONFIG_DIR … コンフィグディレクトリ（既定: `./config`）。
@@ -99,5 +116,5 @@
 - dummy: 最後の user メッセージを `dummy:<text>` として返す。
 
 ## 8. 互換性・拡張
-- 将来のSSEやTPM制御は defaults/providers 拡張で導入予定。
+- SSE配信・TPM制御は現仕様でサポート。旧挙動が必要な場合は `stream:false` や従来設定を維持。
 - 互換差異で破壊的変更が必要な場合は、新しいヘッダやルート名を導入し既存を維持。


### PR DESCRIPTION
## Summary
- document the streaming SSE contract for POST /v1/chat/completions including retry-after errors and telemetry headers
- extend configuration guidance for weighted/priority/sticky routing, circuit breakers, CORS/API keys, and hot reload steps
- refresh rate control and metrics sections to describe TPM windows plus Prometheus/OpenTelemetry alongside JSONL logs

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f36ab2a87083219918d95c3a981016