### PR TITLE
Add optional OpenTelemetry metrics export

### DIFF
--- a/src/orch/metrics.py
+++ b/src/orch/metrics.py
@@ -1,18 +1,150 @@
-import os, json, time
-from typing import Any
+"""Metrics logging with optional OpenTelemetry export.
+
+Set ``ORCH_OTEL_METRICS_EXPORT`` to emit ``requests_total`` and ``latency_ms``
+metrics alongside the JSONL audit log. ``MetricsLogger.flush`` forces an export
+and ``configure_metric_reader`` swaps the underlying reader for tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+import time
+from typing import Any, ClassVar, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from opentelemetry.sdk.metrics.export import MetricReader
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+_FLAG = "ORCH_OTEL_METRICS_EXPORT"
+
+
+def _env_var_as_bool(name: str, *, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if not normalized:
+        return default
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    return default
+
+
+class _OtelMetrics:
+    __slots__ = ("_reader", "_previous_provider", "_provider", "_requests_counter", "_latency_histogram", "_shutdown")
+
+    def __init__(self, reader: Optional["MetricReader"] = None):
+        from opentelemetry import metrics as otel_metrics
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from opentelemetry.sdk.resources import Resource
+
+        self._reader = reader or InMemoryMetricReader()
+        self._previous_provider = otel_metrics.get_meter_provider()
+        provider = MeterProvider(
+            resource=Resource.create({"service.name": "llm-orch"}),
+            metric_readers=[self._reader],
+        )
+        otel_metrics.set_meter_provider(provider)
+        self._provider = provider
+        meter = otel_metrics.get_meter("orch.metrics")
+        self._requests_counter = meter.create_counter(
+            "requests_total", description="Total number of orchestrated requests."
+        )
+        self._latency_histogram = meter.create_histogram(
+            "latency_ms", unit="ms", description="Request latency in milliseconds."
+        )
+        self._shutdown = False
+
+    def record(self, payload: dict[str, Any]) -> None:
+        attrs: dict[str, Any] = {}
+        provider = payload.get("provider")
+        if isinstance(provider, str) and provider:
+            attrs["provider"] = provider
+        status = payload.get("status")
+        if isinstance(status, int) and not isinstance(status, bool):
+            attrs["status"] = status
+        ok = payload.get("ok")
+        if isinstance(ok, bool):
+            attrs["ok"] = ok
+        self._requests_counter.add(1, attributes=attrs)
+        latency = payload.get("latency_ms")
+        if isinstance(latency, (int, float)):
+            self._latency_histogram.record(float(latency), attributes=attrs)
+
+    async def flush(self) -> None:
+        if self._shutdown:
+            return
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._provider.force_flush)
+
+    def shutdown(self) -> None:
+        if self._shutdown:
+            return
+        from opentelemetry import metrics as otel_metrics
+
+        self._provider.shutdown()
+        otel_metrics.set_meter_provider(self._previous_provider)
+        self._shutdown = True
+
 
 class MetricsLogger:
+    _otel_lock: ClassVar[threading.Lock] = threading.Lock()
+    _otel_instance: ClassVar[Optional[_OtelMetrics]] = None
+    _otel_error: ClassVar[bool] = False
+    _custom_reader: ClassVar[Optional["MetricReader"]] = None
+
     def __init__(self, dirpath: str):
         self.dir = dirpath
         os.makedirs(self.dir, exist_ok=True)
+        self._lock: Optional[asyncio.Lock] = None
+        self._otel = self._ensure_otel()
+
+    @classmethod
+    def configure_metric_reader(cls, reader: Optional["MetricReader"]) -> None:
+        with cls._otel_lock:
+            if cls._otel_instance is not None:
+                cls._otel_instance.shutdown()
+            cls._otel_instance = None
+            cls._custom_reader = reader
+            cls._otel_error = False
+
+    @classmethod
+    def _ensure_otel(cls) -> Optional[_OtelMetrics]:
+        if not _env_var_as_bool(_FLAG):
+            return None
+        with cls._otel_lock:
+            if cls._otel_instance is not None:
+                return cls._otel_instance
+            if cls._otel_error:
+                return None
+            try:
+                cls._otel_instance = _OtelMetrics(cls._custom_reader)
+            except ImportError:
+                cls._otel_error = True
+                cls._otel_instance = None
+            return cls._otel_instance
 
     def _file(self) -> str:
-        day = time.strftime("%Y%m%d")
-        return os.path.join(self.dir, f"requests-{day}.jsonl")
+        return os.path.join(self.dir, f"requests-{time.strftime('%Y%m%d')}.jsonl")
 
     async def write(self, record: dict[str, Any]):
-        path = self._file()
-        line = json.dumps(record, ensure_ascii=False)
-        # async not needed here; keep simple buffered write
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(line + "\n")
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        async with self._lock:
+            with open(self._file(), "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+        otel = self._otel or self._ensure_otel()
+        if otel is not None:
+            otel.record(record)
+
+    async def flush(self) -> None:
+        otel = self._otel or self._ensure_otel()
+        if otel is not None:
+            await otel.flush()

--- a/tests/test_metrics_logger.py
+++ b/tests/test_metrics_logger.py
@@ -1,0 +1,236 @@
+"""MetricsLogger OpenTelemetry integration tests."""
+
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _install_otel_stub() -> None:
+    if "opentelemetry" in sys.modules:
+        return
+
+    class MetricsData:
+        def __init__(self, resource_metrics: Iterable["ResourceMetrics"]) -> None:
+            self.resource_metrics = list(resource_metrics)
+
+    class ResourceMetrics:
+        def __init__(self, scope_metrics: Iterable["ScopeMetrics"]) -> None:
+            self.scope_metrics = list(scope_metrics)
+
+    class ScopeMetrics:
+        def __init__(self, metrics: Iterable["_Metric"]) -> None:
+            self.metrics = list(metrics)
+
+    class SumDataPoint:
+        def __init__(self, value: float, attributes: Dict[str, Any]):
+            self.value = value
+            self.attributes = attributes
+
+    class HistogramDataPoint:
+        def __init__(self, count: int, total: float, attributes: Dict[str, Any]):
+            self.count = count
+            self.sum = total
+            self.attributes = attributes
+
+    class Sum:
+        def __init__(self, data_points: Iterable[SumDataPoint]):
+            self.data_points = list(data_points)
+
+    class Histogram:
+        def __init__(self, data_points: Iterable[HistogramDataPoint]):
+            self.data_points = list(data_points)
+
+    class _Metric:
+        def __init__(self, name: str, data: Any):
+            self.name = name
+            self.data = data
+
+    class MetricReader:
+        def __init__(self) -> None:
+            self._metrics_data = MetricsData([])
+
+        def _receive_metrics(self, data: MetricsData) -> None:
+            self._metrics_data = data
+
+    class InMemoryMetricReader(MetricReader):
+        def get_metrics_data(self) -> MetricsData:
+            return self._metrics_data
+
+    class _CounterInstrument:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.records: List[Tuple[float, Dict[str, Any]]] = []
+
+        def add(self, value: float, attributes: Dict[str, Any] | None = None) -> None:
+            self.records.append((float(value), dict(attributes or {})))
+
+    class _HistogramInstrument:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.records: List[Tuple[float, Dict[str, Any]]] = []
+
+        def record(self, value: float, attributes: Dict[str, Any] | None = None) -> None:
+            self.records.append((float(value), dict(attributes or {})))
+
+    class _Meter:
+        def __init__(self) -> None:
+            self.counters: List[_CounterInstrument] = []
+            self.histograms: List[_HistogramInstrument] = []
+
+        def create_counter(self, name: str, **_: Any) -> _CounterInstrument:
+            counter = _CounterInstrument(name)
+            self.counters.append(counter)
+            return counter
+
+        def create_histogram(self, name: str, **_: Any) -> _HistogramInstrument:
+            hist = _HistogramInstrument(name)
+            self.histograms.append(hist)
+            return hist
+
+    class MeterProvider:
+        def __init__(self, *, resource: Any | None = None, metric_readers: Iterable[MetricReader] | None = None) -> None:
+            self._resource = resource
+            self._metric_readers = list(metric_readers or [])
+            self._meters: Dict[str, _Meter] = {}
+            self._shutdown = False
+
+        def get_meter(self, name: str) -> _Meter:
+            return self._meters.setdefault(name, _Meter())
+
+        def force_flush(self) -> bool:
+            metrics: List[_Metric] = []
+            for meter in self._meters.values():
+                for counter in meter.counters:
+                    if counter.records:
+                        points = [SumDataPoint(value, attrs) for value, attrs in counter.records]
+                        counter.records.clear()
+                        metrics.append(_Metric(counter.name, Sum(points)))
+                for hist in meter.histograms:
+                    if hist.records:
+                        points = [HistogramDataPoint(1, value, attrs) for value, attrs in hist.records]
+                        hist.records.clear()
+                        metrics.append(_Metric(hist.name, Histogram(points)))
+            data = MetricsData([ResourceMetrics([ScopeMetrics(metrics)])]) if metrics else MetricsData([])
+            for reader in self._metric_readers:
+                reader._receive_metrics(data)
+            return True
+
+        def shutdown(self) -> bool:
+            self._shutdown = True
+            return True
+
+    class Resource:
+        def __init__(self, attributes: Dict[str, Any]):
+            self.attributes = attributes
+
+        @classmethod
+        def create(cls, attributes: Dict[str, Any]) -> "Resource":
+            return cls(attributes)
+
+    otel_pkg = types.ModuleType("opentelemetry")
+    metrics_mod = types.ModuleType("opentelemetry.metrics")
+    metrics_mod._provider = MeterProvider(metric_readers=[])
+
+    def _get_meter_provider() -> MeterProvider:
+        return metrics_mod._provider
+
+    def _set_meter_provider(provider: MeterProvider) -> None:
+        metrics_mod._provider = provider
+
+    def _get_meter(name: str) -> _Meter:
+        return metrics_mod._provider.get_meter(name)
+
+    metrics_mod.get_meter_provider = _get_meter_provider  # type: ignore[attr-defined]
+    metrics_mod.set_meter_provider = _set_meter_provider  # type: ignore[attr-defined]
+    metrics_mod.get_meter = _get_meter  # type: ignore[attr-defined]
+
+    sdk_pkg = types.ModuleType("opentelemetry.sdk")
+    metrics_pkg = types.ModuleType("opentelemetry.sdk.metrics")
+    export_pkg = types.ModuleType("opentelemetry.sdk.metrics.export")
+    resources_pkg = types.ModuleType("opentelemetry.sdk.resources")
+
+    export_pkg.MetricReader = MetricReader  # type: ignore[attr-defined]
+    export_pkg.InMemoryMetricReader = InMemoryMetricReader  # type: ignore[attr-defined]
+    metrics_pkg.MeterProvider = MeterProvider  # type: ignore[attr-defined]
+    resources_pkg.Resource = Resource  # type: ignore[attr-defined]
+
+    otel_pkg.metrics = metrics_mod  # type: ignore[attr-defined]
+    sdk_pkg.metrics = metrics_pkg  # type: ignore[attr-defined]
+    sdk_pkg.resources = resources_pkg  # type: ignore[attr-defined]
+
+    sys.modules["opentelemetry"] = otel_pkg
+    sys.modules["opentelemetry.metrics"] = metrics_mod
+    sys.modules["opentelemetry.sdk"] = sdk_pkg
+    sys.modules["opentelemetry.sdk.metrics"] = metrics_pkg
+    sys.modules["opentelemetry.sdk.metrics.export"] = export_pkg
+    sys.modules["opentelemetry.sdk.resources"] = resources_pkg
+
+
+try:  # pragma: no cover - executed during import
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader  # type: ignore[assignment]
+except ModuleNotFoundError:  # pragma: no cover - fallback for test environment
+    _install_otel_stub()
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader  # type: ignore[assignment]
+
+from src.orch.metrics import MetricsLogger
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_metrics_logger_records_opentelemetry_samples(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORCH_OTEL_METRICS_EXPORT", "1")
+    reader = InMemoryMetricReader()
+    MetricsLogger.configure_metric_reader(reader)
+
+    try:
+        logger = MetricsLogger(str(tmp_path))
+        record = {
+            "req_id": "req-1",
+            "ts": 1.0,
+            "task": "demo",
+            "provider": "provider-a",
+            "model": "model-x",
+            "latency_ms": 123.0,
+            "ok": True,
+            "status": 200,
+            "error": None,
+            "usage_prompt": 1,
+            "usage_completion": 2,
+            "retries": 0,
+        }
+        await logger.write(record)
+        await logger.flush()
+
+        metrics_data = reader.get_metrics_data()
+        counter_points: list[Any] = []
+        histogram_points: list[Any] = []
+        for resource_metrics in metrics_data.resource_metrics:
+            for scope_metrics in resource_metrics.scope_metrics:
+                for metric in scope_metrics.metrics:
+                    if metric.name == "requests_total":
+                        counter_points.extend(metric.data.data_points)
+                    if metric.name == "latency_ms":
+                        histogram_points.extend(metric.data.data_points)
+
+        assert counter_points, "requests_total counter must have data points"
+        assert histogram_points, "latency_ms histogram must have data points"
+
+        assert any(getattr(dp, "value", 0) == 1 for dp in counter_points)
+        assert any(
+            getattr(dp, "count", 0) == 1 and pytest.approx(getattr(dp, "sum", 0.0)) == record["latency_ms"]
+            for dp in histogram_points
+        )
+    finally:
+        MetricsLogger.configure_metric_reader(None)
+        monkeypatch.delenv("ORCH_OTEL_METRICS_EXPORT", raising=False)


### PR DESCRIPTION
## Summary
- integrate OpenTelemetry meter initialization into `MetricsLogger` behind the `ORCH_OTEL_METRICS_EXPORT` flag while keeping JSONL logging
- expose helpers to configure the metric reader and flush metrics for deterministic tests
- add a metrics logger test with an in-memory OTEL stub to validate counter and histogram samples

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f36ab46ae08321a08534cc6be0b791