### PR TITLE
Add OpenAI stream chat expectation tests

### DIFF
--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -1,7 +1,8 @@
 import asyncio
 import sys
+from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import httpx
 import pytest
@@ -13,6 +14,12 @@ if str(PROJECT_ROOT) not in sys.path:
 from src.orch.providers import OpenAICompatProvider  # noqa: E402
 from src.orch.router import ProviderDef  # noqa: E402
 from src.orch.types import ProviderChatResponse, chat_response_from_provider  # noqa: E402
+
+
+class ProviderStreamChunk(TypedDict, total=False):
+    index: int
+    delta: dict[str, Any]
+    finish_reason: str | None
 
 
 def run_chat(
@@ -314,3 +321,83 @@ def test_openai_chat_response_uses_requested_model_when_missing(monkeypatch: pyt
 
     assert post_calls
     assert response.model == "gpt-4.1-mini"
+
+
+class FakeOpenAIStreamClient:
+    def __init__(self, chunks: list[ProviderStreamChunk], *, error: Exception | None = None) -> None:
+        self._chunks = chunks
+        self._error = error
+        self.calls: list[dict[str, Any]] = []
+
+    async def stream_chat(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        stop_event: asyncio.Event | None = None,
+    ) -> AsyncGenerator[ProviderStreamChunk, None]:
+        self.calls.append({"model": model, "messages": messages, "stop_event": stop_event})
+        if self._error is not None:
+            if stop_event is not None:
+                stop_event.set()
+            raise self._error
+        for chunk in self._chunks:
+            yield chunk
+        if stop_event is not None:
+            stop_event.set()
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_chat_emits_expected_deltas(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    provider = make_provider("https://api.openai.com")
+    expected_chunks: list[ProviderStreamChunk] = [
+        {"index": 0, "delta": {"role": "assistant"}},
+        {"index": 0, "delta": {"content": "hel"}},
+        {"index": 0, "delta": {"content": "lo"}},
+        {"index": 0, "delta": {}, "finish_reason": "stop"},
+    ]
+    fake_client = FakeOpenAIStreamClient(expected_chunks)
+    monkeypatch.setattr(provider, "_openai_client", fake_client, raising=False)
+    stop_event = asyncio.Event()
+
+    async def collect() -> list[ProviderStreamChunk]:
+        results: list[ProviderStreamChunk] = []
+        async for chunk in provider.stream_chat(  # type: ignore[attr-defined]
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hello"}],
+            stop_event=stop_event,
+        ):
+            results.append(chunk)
+        return results
+
+    collected = await collect()
+
+    assert fake_client.calls
+    assert collected == expected_chunks
+    assert stop_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_chat_stops_on_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    provider = make_provider("https://api.openai.com")
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(status_code=429, request=request)
+    error = httpx.HTTPStatusError("Too Many Requests", request=request, response=response)
+    stop_event = asyncio.Event()
+    fake_client = FakeOpenAIStreamClient([], error=error)
+    monkeypatch.setattr(provider, "_openai_client", fake_client, raising=False)
+
+    async def consume() -> None:
+        async for _ in provider.stream_chat(  # type: ignore[attr-defined]
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hello"}],
+            stop_event=stop_event,
+        ):
+            pass
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await consume()
+
+    assert stop_event.is_set(), "429発生時はストップイベントが発火する前提"


### PR DESCRIPTION
## Summary
- introduce a placeholder ProviderStreamChunk schema in the OpenAI provider tests
- add async stream chat tests that define expected delta chunks and stop-event semantics for rate limits

## Testing
- not run (tests currently fail to drive future implementation)


------
https://chatgpt.com/codex/tasks/task_e_68f36f839b648321a907cf77f3fd0173