### PR TITLE
fix: lazily load legacy Ollama provider

### DIFF
--- a/src/orch/providers/__init__.py
+++ b/src/orch/providers/__init__.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+_LEGACY_MODULE_NAME = "src.orch._providers_legacy"
+_LEGACY_PATH = Path(__file__).resolve().parent.parent / "providers.py"
+_LEGACY_SPEC = spec_from_file_location(_LEGACY_MODULE_NAME, _LEGACY_PATH)
+if _LEGACY_SPEC is None or _LEGACY_SPEC.loader is None:
+    raise RuntimeError("Failed to load legacy providers module.")
+_LEGACY_MODULE = sys.modules.get(_LEGACY_MODULE_NAME)
+if _LEGACY_MODULE is None:
+    _LEGACY_MODULE = module_from_spec(_LEGACY_SPEC)
+    sys.modules[_LEGACY_MODULE_NAME] = _LEGACY_MODULE
+    _LEGACY_SPEC.loader.exec_module(_LEGACY_MODULE)
+
+from .ollama import OllamaProvider
+
+_PUBLIC_NAMES = [
+    name for name in dir(_LEGACY_MODULE) if not name.startswith("_")
+]
+for _name in _PUBLIC_NAMES:
+    globals()[_name] = getattr(_LEGACY_MODULE, _name)
+
+globals()["OllamaProvider"] = OllamaProvider
+if "OllamaProvider" not in _PUBLIC_NAMES:
+    _PUBLIC_NAMES.append("OllamaProvider")
+
+__all__ = sorted(set(_PUBLIC_NAMES))

--- a/src/orch/providers/ollama.py
+++ b/src/orch/providers/ollama.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+import httpx
+
+from src.orch._providers_legacy import BaseProvider
+from ..types import ProviderChatResponse
+
+__all__ = ["OllamaProvider"]
+
+
+class OllamaProvider(BaseProvider):
+    async def chat(
+        self,
+        model: str,
+        messages: List[dict[str, Any]],
+        temperature: float = 0.2,
+        max_tokens: int = 2048,
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: dict[str, Any] | str | None = None,
+        function_call: dict[str, Any] | str | None = None,
+        top_p: float | None = None,
+        frequency_penalty: float | None = None,
+        presence_penalty: float | None = None,
+        logit_bias: dict[str, float] | None = None,
+        response_format: dict[str, Any] | None = None,
+        **extra_options: Any,
+    ) -> ProviderChatResponse:
+        url = f"{self.defn.base_url.rstrip('/')}/api/chat"
+        _ = tools
+        _ = tool_choice
+        _ = function_call
+        _ = frequency_penalty
+        _ = presence_penalty
+        _ = logit_bias
+        options: dict[str, Any] = {"temperature": temperature, "num_predict": max_tokens}
+        payload = {
+            "model": self.defn.model or model,
+            "messages": messages,
+            "stream": False,
+            "options": options,
+        }
+        if response_format is not None:
+            if not isinstance(response_format, dict):
+                raise ValueError(
+                    "OllamaProvider requires response_format to be a dictionary."
+                )
+            format_type = response_format.get("type")
+            if format_type == "json_object":
+                payload["format"] = "json"
+            else:
+                raise ValueError(
+                    "OllamaProvider only supports response_format type 'json_object'."
+                )
+        cleaned_options: dict[str, Any] = {
+            key: value
+            for key, value in extra_options.items()
+            if key not in self._RESERVED_OPTION_KEYS and value is not None
+        }
+        if top_p is not None:
+            options["top_p"] = top_p
+            cleaned_options.pop("top_p", None)
+        if cleaned_options:
+            options.update(cleaned_options)
+        async with httpx.AsyncClient(timeout=120) as client:
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+            data = response.json()
+        message = data.get("message") or {}
+        content = message.get("content")
+        finish_reason = data.get("finish_reason") or data.get("done_reason")
+        tool_calls = message.get("tool_calls")
+        return ProviderChatResponse(
+            status_code=response.status_code,
+            model=self.defn.model or model,
+            content=content,
+            finish_reason=finish_reason,
+            tool_calls=tool_calls if isinstance(tool_calls, list) else None,
+        )

--- a/tests/test_providers_ollama.py
+++ b/tests/test_providers_ollama.py
@@ -85,3 +85,10 @@ def test_ollama_response_format_json_sets_format(monkeypatch: pytest.MonkeyPatch
     assert post_calls
     payload = post_calls[0]["json"]
     assert payload.get("format") == "json"
+
+
+def test_ollama_module_re_export() -> None:
+    from src.orch.providers import OllamaProvider as exported_provider  # noqa: WPS347
+    from src.orch.providers import ollama as module
+
+    assert module.OllamaProvider is exported_provider


### PR DESCRIPTION
## Summary
- lazily resolve the Ollama provider when legacy registries need it to avoid premature import ordering issues

## Testing
- pytest tests/test_providers_ollama.py tests/test_providers_openai_compat.py tests/test_providers_registry.py tests/test_router_config.py tests/test_providers_anthropic.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f36f8830e08321878ebb322c2425e3