### PR TITLE
Add metadata fields to provider stream chunk model

### DIFF
--- a/src/orch/types.py
+++ b/src/orch/types.py
@@ -65,8 +65,14 @@ class ProviderStreamChoice(BaseModel):
 class ProviderStreamChunk(BaseModel):
     model_config = ConfigDict(extra="allow")
 
+    event_type: str | None = None
+    index: int | None = None
+    delta: dict[str, Any] | str | None = None
+    finish_reason: str | None = None
     choices: list[ProviderStreamChoice] = Field(default_factory=list)
     usage: dict[str, int] | None = None
+    error: dict[str, Any] | None = None
+    raw: dict[str, Any] | None = None
 
 
 class ProviderChatResponse(BaseModel):


### PR DESCRIPTION
## Summary
- add optional metadata fields to the ProviderStreamChunk pydantic model so event-type data survives normalization

## Testing
- pytest tests/test_providers_anthropic.py::test_anthropic_stream_normalizes_text_events -q
- pytest tests/test_providers_anthropic.py::test_anthropic_stream_yields_usage_and_stop_reason -q
- pytest tests/test_providers_anthropic.py::test_anthropic_stream_emits_rate_limit_error -q

------
https://chatgpt.com/codex/tasks/task_e_68f37f7adf94832184945fa9ec95f05b