### PR TITLE
Add guard TPM support and planner usage tracking

### DIFF
--- a/config/providers.toml
+++ b/config/providers.toml
@@ -6,6 +6,7 @@ model = "gpt-4.1-mini"
 auth_env = "OPENAI_API_KEY"
 rpm = 120
 concurrency = 8
+tpm = 60000
 
 [frontier_backup]
 type = "anthropic"
@@ -14,6 +15,7 @@ model = "claude-3-5-sonnet-20241022"
 auth_env = "ANTHROPIC_API_KEY"
 rpm = 60
 concurrency = 6
+tpm = 60000
 
 [hosted_fast]
 type = "openai" # GroqはOpenAI互換エンドポイントで利用可
@@ -22,6 +24,7 @@ model = "llama-3.1-8b-instruct"
 auth_env = "GROQ_API_KEY"
 rpm = 120
 concurrency = 16
+tpm = 90000
 
 [local_7b]
 type = "ollama"
@@ -29,3 +32,4 @@ base_url = "http://127.0.0.1:11434"
 model = "qwen2.5:7b-instruct-q4_K_M"
 rpm = 9999
 concurrency = 4
+tpm = 120000

--- a/src/orch/rate_limiter.py
+++ b/src/orch/rate_limiter.py
@@ -219,7 +219,9 @@ class _GuardContext:
 
 class ProviderGuards:
   def __init__(self, providers: Dict[str, ProviderDef]):
-    self.guards: Dict[str, Guard] = {name: Guard(p.rpm, p.concurrency) for name, p in providers.items()}
+    self.guards: Dict[str, Guard] = {
+      name: Guard(p.rpm, p.concurrency, p.tpm) for name, p in providers.items()
+    }
 
   def get(self, name: str) -> Guard:
     return self.guards[name]

--- a/src/orch/router.py
+++ b/src/orch/router.py
@@ -21,6 +21,7 @@ class ProviderDef:
     auth_env: str | None
     rpm: int
     concurrency: int
+    tpm: int | None = None
 
 @dataclass
 class RouterDefaults:
@@ -194,6 +195,7 @@ def load_config(config_dir: str, use_dummy: bool=False) -> LoadedConfig:
             auth_env=d.get("auth_env"),
             rpm=int(d.get("rpm", 60)),
             concurrency=_read_concurrency(name, d.get("concurrency", 4)),
+            tpm=int(d["tpm"]) if d.get("tpm") is not None else None,
         )
     router_path = os.path.join(config_dir, "router.yaml")
     with open(router_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- add provider TPM configuration throughout the router and rate limiter to instantiate guards with token-minute ceilings
- update the chat orchestration loop to estimate prompt tokens, acquire token-aware guard leases, and record planner outcomes
- extend server and rate limiter tests to cover guard usage accounting and TPM propagation, and update sample configs with TPM values

## Testing
- pytest tests/test_rate_limiter.py::test_provider_guards_passes_tpm \
       tests/test_server_routes.py::test_chat_uses_guard_estimates_and_records_usage \
       tests/test_server_routes.py::test_chat_records_planner_failure_on_guarded_errors -q


------
https://chatgpt.com/codex/tasks/task_e_68f380f60f008321a98b8f659af005f1