### PR TITLE
Fix setup-node cache when lockfiles absent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,11 @@ jobs:
       - uses: actions/checkout@v4
       - run: mkdir -p workflow-cookbook/logs
       - uses: actions/setup-node@v4
+        if: ${{ hashFiles('**/package-lock.json') == '' }}
+        with:
+          node-version: '22'
+      - uses: actions/setup-node@v4
+        if: ${{ hashFiles('**/package-lock.json') != '' }}
         with:
           node-version: '22'
           cache: npm
@@ -43,6 +48,11 @@ jobs:
       - uses: actions/checkout@v4
       - run: mkdir -p workflow-cookbook/logs
       - uses: actions/setup-node@v4
+        if: ${{ hashFiles('**/package-lock.json') == '' }}
+        with:
+          node-version: '22'
+      - uses: actions/setup-node@v4
+        if: ${{ hashFiles('**/package-lock.json') != '' }}
         with:
           node-version: '22'
           cache: npm
@@ -69,6 +79,12 @@ jobs:
       - run: mkdir -p workflow-cookbook/logs
 
       - uses: actions/setup-node@v4
+        if: ${{ hashFiles('**/package-lock.json') == '' }}
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-node@v4
+        if: ${{ hashFiles('**/package-lock.json') != '' }}
         with:
           node-version: '22'
           cache: npm
@@ -150,6 +166,11 @@ jobs:
       - uses: actions/checkout@v4
       - run: mkdir -p workflow-cookbook/logs dist
       - uses: actions/setup-node@v4
+        if: ${{ hashFiles('**/package-lock.json') == '' }}
+        with:
+          node-version: '22'
+      - uses: actions/setup-node@v4
+        if: ${{ hashFiles('**/package-lock.json') != '' }}
         with:
           node-version: '22'
           cache: npm


### PR DESCRIPTION
## Summary
- avoid failing setup-node cache configuration when the repository has no package-lock.json
- always provision Node.js while only enabling npm caching when lockfiles are present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f39c60ead88321bd3f330f765a85f8