### PR TITLE
Fix e2e workflow skip condition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,7 +219,9 @@ jobs:
       - name: Playwright E2E (if exists)
         run: |
           set -Eeuo pipefail
-          if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts&&p.scripts['test:e2e']))"; then
+          if [ ! -f package.json ]; then
+            echo "{\"name\":\"e2e\",\"status\":\"skip\",\"duration_ms\":0}" >> workflow-cookbook/logs/test.jsonl
+          elif node -e "p=require('./package.json');process.exit(!(p.scripts&&p.scripts['test:e2e']))"; then
             echo "{\"name\":\"e2e\",\"status\":\"skip\",\"duration_ms\":0}" >> workflow-cookbook/logs/test.jsonl
           else
             start=$(date +%s%3N)


### PR DESCRIPTION
## Summary
- ensure the Playwright e2e step skips when no package.json is present
- keep existing skip behaviour for repos without a test:e2e script

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68f3a13a8f54832189b2b861f727e925