### PR TITLE
Refresh Birdseye docs for provider refactor

### DIFF
--- a/docs/birdseye/caps/src.orch.router.py.json
+++ b/docs/birdseye/caps/src.orch.router.py.json
@@ -7,7 +7,7 @@
   ],
   "summary": "プロバイダ/ルート設定ファイルを読み込み、Pydanticバリデーションとdataclassに変換。RoutePlannerでtask→ルート決定、再利用可能なロード監視情報(mtimes/watch_paths)も保持。",
   "deps_out": [
-    "src/orch/providers.py"
+    "src/orch/providers/__init__.py"
   ],
   "deps_in": [
     "src/orch/server.py"

--- a/docs/birdseye/caps/src.orch.server.py.json
+++ b/docs/birdseye/caps/src.orch.server.py.json
@@ -5,7 +5,7 @@
     "GET /healthz",
     "POST /v1/chat/completions"
   ],
-  "summary": "FastAPIエントリポイント。設定を読み込みProviderRegistry/RoutePlanner/ProviderGuardsを初期化し、RPMとTPMをまとめて制御するガードでPrometheusメトリクスとJSONLロガーへ記録。SSEストリーミングと非ストリーミングを両対応し、プロバイダフォールバックを逐次試行する。",
+  "summary": "FastAPIエントリポイント。設定を読み込みProviderRegistry/RoutePlanner/ProviderGuardsを初期化し、RPM/TPM統合ガード越しにフォールバック順でプロバイダ呼び出しを実行。SSE/非SSEを動的に切り替えつつPrometheusメトリクスとJSONLログへ書き出す。",
   "deps_out": [
     "src/orch/router.py",
     "src/orch/providers/__init__.py",
@@ -15,9 +15,9 @@
   ],
   "deps_in": [],
   "risks": [
-    "SSEストリームはクライアント切断検知までガードを保持するためリソース占有が長引く恐れ",
-    "フォールバック試行が全滅すると429/5xx時にRetry-After推定へ依存する",
-    "PrometheusカウンタとTPMバケットは設定とズレるとメトリクス解釈を誤る"
+    "SSE接続はクライアント切断までGuard/HTTPリソースを保持し続ける",
+    "フォールバック連鎖でRPM/TPM在庫が枯渇すると再試行が遅延または失敗する",
+    "Prometheus/JSONL出力とTPMバケットの設定ズレでメトリクス/制限値の解釈が狂う"
   ],
   "tests": [
     "tests/test_server_routes.py",

--- a/docs/birdseye/index.json
+++ b/docs/birdseye/index.json
@@ -1,20 +1,20 @@
 {
-  "generated_at": "2025-10-18T16:11:41Z",
+  "generated_at": "2025-10-18T16:35:55Z",
   "nodes": {
     "src/orch/server.py": {
       "role": "entrypoint",
       "caps": "docs/birdseye/caps/src.orch.server.py.json",
-      "mtime": "2024-10-10T00:00:00Z"
+      "mtime": "2025-10-18T16:35:55Z"
     },
     "src/orch/router.py": {
       "role": "application",
       "caps": "docs/birdseye/caps/src.orch.router.py.json",
-      "mtime": "2024-10-10T00:00:00Z"
+      "mtime": "2025-10-18T16:35:55Z"
     },
     "src/orch/providers/__init__.py": {
       "role": "application",
       "caps": "docs/birdseye/caps/src.orch.providers.__init__.py.json",
-      "mtime": "2024-10-10T00:00:00Z"
+      "mtime": "2025-10-18T16:35:55Z"
     }
   },
   "edges": [


### PR DESCRIPTION
## Summary
- update the Birdseye index timestamp and node metadata to match the current provider package entry point
- refresh the server capsule summary/risks to describe SSE fallback behaviour and Prometheus/TPM integration
- point the router capsule at src/orch/providers/__init__.py instead of the removed providers.py

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f3c18ba69c83219b731bdd913b6e2b