### PR TITLE
Add concurrency cancellation to GitHub workflows

### DIFF
--- a/.github/workflows/ci-py.yml
+++ b/.github/workflows/ci-py.yml
@@ -1,5 +1,8 @@
 name: ci-py
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,9 @@ on:
   pull_request: { branches: [ main ] }
   schedule:
     - cron: '0 18 * * 0'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   security-events: write

--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -1,5 +1,8 @@
 name: pr-gate
 on: [pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/reflection.yml
+++ b/.github/workflows/reflection.yml
@@ -5,6 +5,9 @@ on:
     types: [completed]
   schedule:
     - cron: "0 3 * * *"   # 毎日3:00 UTC
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   reflect:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary
- add concurrency groups to every workflow to cancel superseded runs
- align existing test workflow to use pull request aware concurrency key

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f3d5e658548321a8ca145f9cd5ce76