### PR TITLE
Handle provider stream chunks in SSE encoding

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -4,6 +4,7 @@ import os
 import time
 import uuid
 from collections import defaultdict
+from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Any
@@ -520,6 +521,15 @@ async def _stream_chat_response(
             data_field = raw_event
         if not isinstance(event_name, str):
             event_name = None
+        if data_field is not None and not isinstance(data_field, str):
+            model_dump = getattr(data_field, "model_dump", None)
+            if callable(model_dump):
+                try:
+                    data_field = model_dump(mode="json", exclude_none=True)
+                except TypeError:
+                    data_field = model_dump()
+            elif is_dataclass(data_field):
+                data_field = asdict(data_field)
         if isinstance(data_field, str):
             data_text = data_field
         elif data_field is None:


### PR DESCRIPTION
## Summary
- add a streaming regression test that uses ProviderStreamChunk to assert SSE payloads include JSON choices
- normalize streaming event payloads with model_dump/asdict before JSON encoding so ProviderStreamChunk instances serialize correctly

## Testing
- pytest tests/test_server_routes.py::test_chat_streams_events tests/test_server_routes.py::test_chat_streams_provider_chunk_events

------
https://chatgpt.com/codex/tasks/task_e_68f3d8e7a0b88321aac6315c32c5d880