### PR TITLE
Ensure guard usage released on provider errors

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -379,6 +379,11 @@ async def chat_completions(req: Request, body: ChatRequest):
                         **provider_kwargs,
                     )
                 except Exception as exc:
+                    guard.record_usage(
+                        lease,
+                        usage_prompt_tokens=0,
+                        usage_completion_tokens=0,
+                    )
                     planner.record_failure(provider_name)
                     last_err = str(exc)
                     last_provider = provider_name


### PR DESCRIPTION
## Summary
- add a regression test that mocks ProviderGuards to ensure TPM reservations are released when providers raise errors
- call `guard.record_usage` with zero usage inside the non-streaming chat loop exception path so all error exits free leases

## Testing
- pytest tests/test_server_routes.py::test_chat_releases_guard_usage_on_provider_exception

------
https://chatgpt.com/codex/tasks/task_e_68f3e30fe4fc8321babb062ddbc898b1