### PR TITLE
Handle streaming HTTP errors without fallback provider

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -756,6 +756,33 @@ async def _stream_chat_response(
 
         producer_task = asyncio.create_task(producer())
         first_kind, first_payload = await queue.get()
+        first_chunk: bytes | None = None
+        prefetched_chunks: list[bytes] = []
+        initial_done = False
+        if first_kind == "data":
+            first_chunk = first_payload
+            await asyncio.sleep(0)
+            drained: list[tuple[str, Any]] = []
+            while True:
+                try:
+                    drained.append(queue.get_nowait())
+                except asyncio.QueueEmpty:
+                    break
+            for kind, payload in drained:
+                if kind == "data":
+                    prefetched_chunks.append(payload)
+                    continue
+                if kind == "done":
+                    initial_done = True
+                    continue
+                if kind in {"error", "fallback"}:
+                    first_kind = kind
+                    first_payload = payload
+                    first_chunk = None
+                    prefetched_chunks.clear()
+                    initial_done = False
+                    break
+                raise RuntimeError("unexpected stream signal")
         if first_kind == "error":
             await producer_task
             status_code = int(first_payload["status"])
@@ -795,15 +822,17 @@ async def _stream_chat_response(
         if first_kind not in {"data", "done"}:
             await producer_task
             raise RuntimeError("unexpected stream signal")
-        first_chunk: bytes | None = None
-        if first_kind == "data":
-            first_chunk = first_payload
 
         async def event_source() -> Any:
             try:
                 if first_chunk is not None:
                     yield first_chunk
+                for chunk in prefetched_chunks:
+                    yield chunk
                 if first_kind == "done":
+                    yield b"data: [DONE]\n\n"
+                    return
+                if initial_done:
                     yield b"data: [DONE]\n\n"
                     return
                 while True:


### PR DESCRIPTION
## Summary
- add a streaming routing test that exercises a primary provider emitting one chunk before raising an HTTPStatusError without a fallback route
- update `_stream_chat_response` to buffer initial events so immediate HTTP/fallback signals return a JSON error with provider details instead of a hanging SSE stream

## Testing
- pytest tests/test_server_streaming_routing.py

------
https://chatgpt.com/codex/tasks/task_e_68f45fbee9bc8321aed04295c6dd4749