### PR TITLE
docs: reflect automatic config reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ curl -s -H "Content-Type: application/json" \
 
 ## 既知の制限（MVP）
 
-- 設定ファイル（`providers.toml` / `router.yaml`）のホットリロードは未対応。
+- 設定ファイル（`providers.toml` / `router.yaml`）は `_config_refresh_loop` が監視し、更新検知時に `reload_configuration()` を通じて自動反映されます。
 - TPMガードは `usage` が欠落するプロバイダでは推定トークンを用いるため、保守的なスロットリングが発生します。

--- a/TASKS.md
+++ b/TASKS.md
@@ -3,3 +3,4 @@
 - [x] README: OpenTelemetryメトリクス説明を更新（`ORCH_OTEL_METRICS_EXPORT` 追記、既知の制限を整理済み）。他タスクは同節の編集時にOTel設定例を保持すること。
 - [x] src/orch/server.py: `_config_refresh_loop` のリロード処理を更新済み。後続タスクは同ロジック変更との重複に注意。最新plannerへの差し替え後は即座に再評価する設計。
 - [x] tests/test_server_config_reload.py: plannerのリロード判定テストを追加済み。重複する検証ケースの再追加を避けること。
+- [x] README: 既知の制限節を `_config_refresh_loop` / `reload_configuration()` の自動監視・反映説明に更新済み。今後の追記でもホットリロード対応済みである点を保持すること。


### PR DESCRIPTION
## Summary
- update the README known limitations section to describe the automatic configuration monitoring handled by `_config_refresh_loop` and `reload_configuration()`
- record the documentation change in TASKS.md to avoid duplicate README edits

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4c15281f48321a017dbff804e0103