### PR TITLE
Ensure routing errors return JSON error responses

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -419,7 +419,9 @@ async def chat_completions(req: Request, body: ChatRequest):
             "usage_completion": 0,
             "retries": 0,
         })
-        raise HTTPException(status_code=400, detail=detail)
+        headers = _make_response_headers(req_id=req_id, provider=None, attempts=0)
+        error_payload = {"message": detail, "type": "routing_error"}
+        return JSONResponse({"error": error_payload}, status_code=400, headers=headers)
     if body.stream:
         return await _stream_chat_response(
             model=body.model,


### PR DESCRIPTION
## Summary
- return JSON-formatted errors with orchestrator headers when routing fails
- add coverage for unroutable task responses and update expectations for routing error assertions

## Testing
- pytest tests/test_server_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68f4db16cb888321a030289e6b31e6b7