### PR TITLE
Fix unused imports in health tests

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,9 +2,7 @@ import importlib
 import os
 import sys
 from pathlib import Path
-import textwrap
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -94,4 +92,9 @@ routes:
         },
     )
     assert response.status_code == 400
-    assert "no route configured" in response.json()["detail"]
+    payload = response.json()
+    if "detail" in payload:
+        message = payload["detail"]
+    else:
+        message = payload.get("error", {}).get("message", "")
+    assert "no route configured" in message


### PR DESCRIPTION
## Summary
- remove unused imports from `tests/test_health.py`
- relax error assertion to handle both legacy and current response formats when defaults are missing

## Testing
- ruff check tests/test_health.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f4e15841d483218b3bc56b97bce254