### PR TITLE
docs: add rate limiter birdseye capsule

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -4,3 +4,4 @@
 - [x] src/orch/server.py: `_config_refresh_loop` のリロード処理を更新済み。後続タスクは同ロジック変更との重複に注意。最新plannerへの差し替え後は即座に再評価する設計。
 - [x] tests/test_server_config_reload.py: plannerのリロード判定テストを追加済み。重複する検証ケースの再追加を避けること。
 - [x] README: 既知の制限節を `_config_refresh_loop` / `reload_configuration()` の自動監視・反映説明に更新済み。今後の追記でもホットリロード対応済みである点を保持すること。
+- [x] docs/birdseye: rate_limiterノード追加とcaps整備（担当: gpt-5-codex、完了）。

--- a/docs/birdseye/caps/src.orch.rate_limiter.py.json
+++ b/docs/birdseye/caps/src.orch.rate_limiter.py.json
@@ -1,0 +1,25 @@
+{
+  "id": "src/orch/rate_limiter.py",
+  "role": "infrastructure",
+  "public_api": [
+    "Guard.acquire(estimated_prompt_tokens=0)",
+    "Guard.record_usage(lease, usage_prompt_tokens, usage_completion_tokens)",
+    "ProviderGuards.get(name)",
+    "SlidingWindowBucket.reserve(tokens, now)"
+  ],
+  "summary": "RPM/TPM/並列の制限を統合し、プロバイダ呼び出しごとに待機/リース管理を行う非同期ガード群。TokenBucketで分単位RPM、SlidingWindowBucketでTPMを維持し、GuardがSemaphoreと組み合わせてAPI呼び出しの整列を担う。",
+  "details": {
+    "ProviderGuards": "ProviderDef群からGuardを初期化し名前→Guardの辞書を提供するファクトリ。サーバ起動時や設定リロード時に呼ばれ、プロバイダごとのrpm/concurrency/tpmをそのままGuardへ伝搬する。",
+    "Guard": "TokenBucket/SlidingWindowBucket/Semaphoreを束ねた非同期コンテキスト。acquire/__aenter__でスロットを確保し、record_usageで実績トークンをコミットしてTPM待機時間を返す。リースはGuardLeaseで追跡し、未使用予約はrelease時にキャンセルする。",
+    "SlidingWindowBucket": "TPM制御用のスライディングウィンドウ。reserveで推定トークンを仮押さえし、commitで実績に置換。window_seconds内のエントリをpruneしながら不足分に応じた待機秒数を計算する。"
+  },
+  "deps_out": [
+    "src/orch/router.py"
+  ],
+  "deps_in": [
+    "src/orch/server.py"
+  ],
+  "tests": [
+    "tests/test_rate_limiter.py"
+  ]
+}

--- a/docs/birdseye/index.json
+++ b/docs/birdseye/index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-10-18T16:35:55Z",
+  "generated_at": "2025-10-19T14:01:37Z",
   "nodes": {
     "src/orch/server.py": {
       "role": "entrypoint",
@@ -15,11 +15,29 @@
       "role": "application",
       "caps": "docs/birdseye/caps/src.orch.providers.__init__.py.json",
       "mtime": "2025-10-18T16:35:55Z"
+    },
+    "src/orch/rate_limiter.py": {
+      "role": "infrastructure",
+      "caps": "docs/birdseye/caps/src.orch.rate_limiter.py.json",
+      "mtime": "2025-10-19T14:01:37Z"
     }
   },
   "edges": [
-    ["src/orch/server.py", "src/orch/router.py"],
-    ["src/orch/server.py", "src/orch/providers/__init__.py"],
-    ["src/orch/router.py", "src/orch/providers/__init__.py"]
+    [
+      "src/orch/server.py",
+      "src/orch/router.py"
+    ],
+    [
+      "src/orch/server.py",
+      "src/orch/providers/__init__.py"
+    ],
+    [
+      "src/orch/router.py",
+      "src/orch/providers/__init__.py"
+    ],
+    [
+      "src/orch/server.py",
+      "src/orch/rate_limiter.py"
+    ]
   ]
 }


### PR DESCRIPTION
## Summary
- add the rate limiter module to the Birdseye index and wire its dependency from the server entrypoint
- document ProviderGuards, Guard, and SlidingWindowBucket in a new capsule referencing rate limiter tests
- note the completed Birdseye documentation task in TASKS.md

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f4eedae144832193cabc5eac57416d