### PR TITLE
Normalize SSE event names for dict-based streaming chunks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -7,3 +7,4 @@
 - [x] docs/birdseye: rate_limiterノード追加とcaps整備（担当: gpt-5-codex、完了）。
 - [x] docs/birdseye: rate_limiterカプセル要約を刷新し index の generated_at を更新（担当: gpt-5-codex、2025-10-19 完了）。
 - [x] tests/test_server_streaming_events.py / src/orch/server.py: SSEイベントの仕様名マッピングと `[DONE]` センチネル互換を担保する実装・テストを追加済み。後続改修時は `chat.completion.chunk` / `telemetry.usage` / `done` のエイリアス維持を徹底すること。
+- [x] tests/test_server_streaming_events.py / src/orch/server.py: dict由来 `event_type` も SSE 仕様イベント名に正規化し、`data` を常に JSON 解釈可能にする改修を実施済み。重複対応を避け、`event`/`event_type` の両経路で仕様名を崩さないこと。

--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -620,8 +620,15 @@ async def _stream_chat_response(
 
     def _encode_event(raw_event: Any) -> bytes:
         if isinstance(raw_event, dict):
-            event_name = raw_event.get("event")
-            data_field = raw_event.get("data")
+            event_name = raw_event.get("event") or raw_event.get("event_type")
+            if "data" in raw_event:
+                data_field = raw_event.get("data")
+            else:
+                data_field = {
+                    key: value
+                    for key, value in raw_event.items()
+                    if key not in {"event", "event_type"}
+                }
         else:
             event_name = getattr(raw_event, "event_type", None)
             data_field = raw_event
@@ -675,6 +682,7 @@ async def _stream_chat_response(
                 data_field = asdict(data_field)
 
         if isinstance(data_field, dict):
+            data_field = dict(data_field)
             data_field.pop("event_type", None)
             data_field.pop("raw", None)
 

--- a/tests/test_server_streaming_events.py
+++ b/tests/test_server_streaming_events.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Callable
 
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -16,7 +17,24 @@ from src.orch.types import ProviderStreamChunk
 from tests.test_server_routes import load_app
 
 
-def test_streaming_events_emit_spec_names(monkeypatch) -> None:
+StreamFn = Callable[..., AsyncIterator[Any]]
+
+
+def _parse_sse_payload(payload: str) -> list[tuple[str | None, str]]:
+    events: list[tuple[str | None, str]] = []
+    for chunk in filter(None, payload.split("\n\n")):
+        event_name: str | None = None
+        data_text = ""
+        for line in chunk.split("\n"):
+            if line.startswith("event: "):
+                event_name = line[len("event: ") :]
+            elif line.startswith("data: "):
+                data_text = line[len("data: ") :]
+        events.append((event_name, data_text))
+    return events
+
+
+def _collect_sse_events(monkeypatch: MonkeyPatch, stream_fn: StreamFn) -> list[tuple[str | None, str]]:
     app = load_app("1")
     server_module = sys.modules["src.orch.server"]
     model_name = "mock-provider"
@@ -27,18 +45,13 @@ def test_streaming_events_emit_spec_names(monkeypatch) -> None:
 
         async def __aexit__(self, exc_type, exc, tb) -> None:
             return None
+
     class _Registry:
         def __init__(self, mapping: dict[str, Any]) -> None:
             self._mapping = mapping
 
         def get(self, key: str) -> Any:
             return self._mapping[key]
-
-    async def _stream(*_args: Any, **_kwargs: Any) -> AsyncIterator[ProviderStreamChunk]:
-        yield ProviderStreamChunk(event_type="message_start", delta={"role": "assistant"})
-        yield ProviderStreamChunk(event_type="delta", delta={"content": "Hel"})
-        yield ProviderStreamChunk(event_type="usage", usage={"prompt_tokens": 3, "completion_tokens": 1})
-        yield ProviderStreamChunk(event_type="message_stop", finish_reason="stop")
 
     route = RouteDef(
         name="PLAN",
@@ -58,7 +71,7 @@ def test_streaming_events_emit_spec_names(monkeypatch) -> None:
     monkeypatch.setattr(
         server_module,
         "providers",
-        _Registry({model_name: type("Provider", (), {"model": model_name, "chat_stream": staticmethod(_stream)})()}),
+        _Registry({model_name: type("Provider", (), {"model": model_name, "chat_stream": staticmethod(stream_fn)})()}),
         raising=False,
     )
     monkeypatch.setattr(server_module, "guards", _Registry({model_name: _Guard()}), raising=False)
@@ -70,16 +83,17 @@ def test_streaming_events_emit_spec_names(monkeypatch) -> None:
         assert response.status_code == 200
         payload = "".join(response.iter_text())
 
-    events: list[tuple[str | None, str]] = []
-    for chunk in filter(None, payload.split("\n\n")):
-        event_name: str | None = None
-        data_text = ""
-        for line in chunk.split("\n"):
-            if line.startswith("event: "):
-                event_name = line[len("event: ") :]
-            elif line.startswith("data: "):
-                data_text = line[len("data: ") :]
-        events.append((event_name, data_text))
+    return _parse_sse_payload(payload)
+
+
+def test_streaming_events_emit_spec_names(monkeypatch: MonkeyPatch) -> None:
+    async def _stream(*_args: Any, **_kwargs: Any) -> AsyncIterator[ProviderStreamChunk]:
+        yield ProviderStreamChunk(event_type="message_start", delta={"role": "assistant"})
+        yield ProviderStreamChunk(event_type="delta", delta={"content": "Hel"})
+        yield ProviderStreamChunk(event_type="usage", usage={"prompt_tokens": 3, "completion_tokens": 1})
+        yield ProviderStreamChunk(event_type="message_stop", finish_reason="stop")
+
+    events = _collect_sse_events(monkeypatch, _stream)
 
     names = {name for name, _ in events if name}
     assert {"chat.completion.chunk", "telemetry.usage", "done"} <= names
@@ -92,4 +106,37 @@ def test_streaming_events_emit_spec_names(monkeypatch) -> None:
             assert parsed == {}
         else:
             assert isinstance(parsed, dict)
+
+
+def test_streaming_dict_events_are_mapped(monkeypatch: MonkeyPatch) -> None:
+    async def _stream(*_args: Any, **_kwargs: Any) -> AsyncIterator[dict[str, Any]]:
+        yield {"event_type": "message_start", "delta": {"role": "assistant"}}
+        yield {"event_type": "delta", "delta": {"content": "Hel"}}
+        yield {"event_type": "usage", "usage": {"prompt_tokens": 3, "completion_tokens": 1}}
+        yield {"event_type": "message_stop", "finish_reason": "stop"}
+
+    events = _collect_sse_events(monkeypatch, _stream)
+
+    named_events = [name for name, _ in events if name]
+    assert named_events[:4] == [
+        "chat.completion.chunk",
+        "chat.completion.chunk",
+        "telemetry.usage",
+        "done",
+    ]
+
+    assert any(name is None and data == "[DONE]" for name, data in events)
+
+    for name, data_text in events:
+        if name is None:
+            assert data_text == "[DONE]"
+            continue
+        if data_text == "":
+            continue
+        parsed = json.loads(data_text)
+        if name == "done":
+            assert parsed == {}
+        else:
+            assert "event_type" not in parsed
+            assert "raw" not in parsed
 


### PR DESCRIPTION
## Summary
- add shared helpers for streaming event tests and cover dict-based provider responses
- map dict event_type payloads to spec SSE event names while stripping internal fields
- note the SSE normalization work in TASKS.md for future coordination

## Testing
- pytest tests/test_server_streaming_events.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f514fb870c8321884edf2989a4c451