### PR TITLE
Refactor SSE streaming encoder and add coverage

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -9,3 +9,4 @@
 - [x] tests/test_server_streaming_events.py / src/orch/server.py: SSEイベントの仕様名マッピングと `[DONE]` センチネル互換を担保する実装・テストを追加済み。後続改修時は `chat.completion.chunk` / `telemetry.usage` / `done` のエイリアス維持を徹底すること。
 - [x] tests/test_server_streaming_events.py / src/orch/server.py: dict由来 `event_type` も SSE 仕様イベント名に正規化し、`data` を常に JSON 解釈可能にする改修を実施済み。重複対応を避け、`event`/`event_type` の両経路で仕様名を崩さないこと。
 - [x] tests/test_server_streaming_events.py / src/orch/server.py: dataclass 由来イベントの `event` 属性を SSE 仕様名へ正規化し、内部フィールドを除外する挙動を追加済み。後続改修でも `done` 終端と `[DONE]` センチネルの整合性を維持すること。
+- [x] tests/test_server_streaming_events.py / src/orch/server.py: `_encode_event` を共通化し Pydantic/dataclass/辞書イベントの JSON 化・イベント名マッピングを一本化済み（担当: gpt-5-codex, 2025-02-15）。後続改修では `_extract_event` / `_coerce_payload` を経由させること。


### PR DESCRIPTION
## Summary
- add tests covering SSE chat streaming to verify spec event names and JSON payloads across provider chunk types
- refactor `_encode_event` in the streaming path to share extraction and coercion logic for dict, Pydantic, and dataclass payloads while keeping terminal handling consistent
- note the shared `_encode_event` helper expectations in TASKS.md for future work coordination

## Testing
- pytest tests/test_server_streaming_events.py


------
https://chatgpt.com/codex/tasks/task_e_68f5207b3ce48321812d4868f672f781