### PR TITLE
Fix OpenAI stream parsing for [DONE] sentinel

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -10,3 +10,4 @@
 - [x] tests/test_server_streaming_events.py / src/orch/server.py: dict由来 `event_type` も SSE 仕様イベント名に正規化し、`data` を常に JSON 解釈可能にする改修を実施済み。重複対応を避け、`event`/`event_type` の両経路で仕様名を崩さないこと。
 - [x] tests/test_server_streaming_events.py / src/orch/server.py: dataclass 由来イベントの `event` 属性を SSE 仕様名へ正規化し、内部フィールドを除外する挙動を追加済み。後続改修でも `done` 終端と `[DONE]` センチネルの整合性を維持すること。
 - [x] tests/test_server_streaming_events.py / src/orch/server.py: `_encode_event` を共通化し Pydantic/dataclass/辞書イベントの JSON 化・イベント名マッピングを一本化済み（担当: gpt-5-codex, 2025-02-15）。後続改修では `_extract_event` / `_coerce_payload` を経由させること。
+- [x] tests/test_providers_openai.py / src/orch/providers/openai.py: OpenAI SSE の `data:` プレフィックス剥離と `[DONE]` センチネル終端処理を共通化済み（担当: gpt-5-codex, 2025-02-19）。追加入力時も `finalize_event` ロジックと usage/delta 正規化を保持すること。


### PR DESCRIPTION
## Summary
- add a regression test that mocks httpx.AsyncClient.stream to emit `data:` lines ending with `[DONE]`
- normalize OpenAICompatProvider.chat_stream to trim the SSE prefix, finalize buffered payloads, and stop when `[DONE]` is received
- note the shared SSE parsing contract in TASKS.md to avoid future duplication

## Testing
- pytest tests/test_providers_openai.py::test_openai_chat_stream_handles_done_without_separator -q

------
https://chatgpt.com/codex/tasks/task_e_68f52624df708321ac0f10c8f7e82b00