### PR TITLE
Add SDK compatibility tests for error responses

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -263,6 +263,32 @@ def _error_type_from_status(status: int | None) -> str:
     return "provider_error"
 
 
+def _make_error_body(
+    *,
+    status_code: int,
+    message: str,
+    error_type: str,
+    retry_after: int | None = None,
+    code: str | None = None,
+) -> dict[str, Any]:
+    resolved_code = code
+    if resolved_code is None:
+        if status_code == 401:
+            resolved_code = "invalid_api_key"
+        elif status_code == 429:
+            resolved_code = "rate_limit"
+        else:
+            resolved_code = error_type
+    payload: dict[str, Any] = {
+        "message": message,
+        "type": error_type,
+        "code": resolved_code,
+    }
+    if retry_after is not None:
+        payload["retry_after"] = retry_after
+    return {"error": payload}
+
+
 def _require_api_key(req: Request) -> None:
     if not INBOUND_API_KEYS:
         return
@@ -341,7 +367,21 @@ async def metrics_endpoint(req: Request) -> Response:
 
 @app.post("/v1/chat/completions")
 async def chat_completions(req: Request, body: ChatRequest):
-    _require_api_key(req)
+    try:
+        _require_api_key(req)
+    except HTTPException as exc:
+        if exc.status_code != 401:
+            raise
+        req_id = str(uuid.uuid4())
+        headers = _make_response_headers(req_id=req_id, provider=None, attempts=0)
+        detail = exc.detail if isinstance(exc.detail, str) else "missing or invalid api key"
+        error_body = _make_error_body(
+            status_code=exc.status_code,
+            message=detail,
+            error_type="authentication_error",
+            code="invalid_api_key",
+        )
+        return JSONResponse(error_body, status_code=exc.status_code, headers=headers)
     header_value = (
         req.headers.get(cfg.router.defaults.task_header)
         if cfg.router.defaults.task_header
@@ -420,8 +460,12 @@ async def chat_completions(req: Request, body: ChatRequest):
             "retries": 0,
         })
         headers = _make_response_headers(req_id=req_id, provider=None, attempts=0)
-        error_payload = {"message": detail, "type": "routing_error"}
-        return JSONResponse({"error": error_payload}, status_code=400, headers=headers)
+        error_body = _make_error_body(
+            status_code=400,
+            message=detail,
+            error_type="routing_error",
+        )
+        return JSONResponse(error_body, status_code=400, headers=headers)
     if body.stream:
         return await _stream_chat_response(
             model=body.model,
@@ -583,18 +627,16 @@ async def chat_completions(req: Request, body: ChatRequest):
     if failure_retry_after is not None:
         failure_record["retry_after"] = failure_retry_after
     await _log_metrics(failure_record)
-    error_payload: dict[str, Any] = {
-        "message": failure_error,
-        "type": failure_error_type,
-    }
-    if failure_retry_after is not None:
-        error_payload["retry_after"] = failure_retry_after
+    error_body = _make_error_body(
+        status_code=failure_status,
+        message=failure_error,
+        error_type=failure_error_type,
+        retry_after=failure_retry_after,
+    )
     headers = _make_response_headers(
         req_id=req_id, provider=last_provider, attempts=attempt_count
     )
-    return JSONResponse(
-        {"error": error_payload}, status_code=failure_status, headers=headers
-    )
+    return JSONResponse(error_body, status_code=failure_status, headers=headers)
 
 
 async def _stream_chat_response(

--- a/tests/test_sdk_error_compat.py
+++ b/tests/test_sdk_error_compat.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json, shutil, subprocess, sys
+from pathlib import Path
+from typing import Any
+
+import httpx, pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.orch import server as orch_server
+
+_PARAMS: list[tuple[int, str, str, dict[str, Any]]] = [
+    (400, "provider_error", "bad request", {}),
+    (401, "authentication_error", "missing or invalid api key", {"code": "invalid_api_key"}),
+    (429, "rate_limit", "rate limited", {"retry_after": orch_server.DEFAULT_RETRY_AFTER_SECONDS}),
+    (502, "provider_server_error", "upstream failed", {}),
+]
+
+
+@pytest.mark.parametrize("status, kind, message, extra", _PARAMS)
+def test_python_openai_sdk(status: int, kind: str, message: str, extra: dict[str, Any]) -> None:
+    openai = pytest.importorskip("openai")
+    body = orch_server._make_error_body(status_code=status, message=message, error_type=kind, **extra)
+    client = openai.OpenAI(
+        api_key="test",
+        base_url="https://mock.local/v1",
+        http_client=httpx.Client(
+            transport=httpx.MockTransport(lambda request: httpx.Response(status_code=status, json=body)),
+            base_url="https://mock.local",
+        ),
+    )
+    with pytest.raises(openai.APIStatusError) as exc:
+        client.chat.completions.create(model="dummy", messages=[{"role": "user", "content": "hi"}])
+    assert exc.value.response.status_code == status
+    assert exc.value.response.json() == body
+
+
+def test_node_openai_sdk() -> None:
+    if shutil.which("node") is None:
+        pytest.skip("node runtime is unavailable")
+    probe = subprocess.run(
+        ["node", "--input-type=module", "-e", "import('openai').then(()=>0,()=>process.exit(1));"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if probe.returncode != 0:
+        pytest.skip("openai package is not installed for node")
+    cases = json.dumps([(status, orch_server._make_error_body(status_code=status, message=message, error_type=kind, **extra)) for status, kind, message, extra in _PARAMS])
+    script = (
+        "import assert from'node:assert/strict';import OpenAI from'openai';import{MockAgent,Agent,setGlobalDispatcher}from'undici';"
+        f"const cases={cases};"
+        "(async()=>{for(const [status,payload]of cases){const agent=new MockAgent();agent.disableNetConnect();const pool=agent.get('https://mock.local');"
+        "pool.intercept({method:'POST',path:'/v1/chat/completions'}).reply(status,payload);setGlobalDispatcher(agent);const client=new OpenAI({apiKey:'test',baseURL:'https://mock.local/v1'});"
+        "let threw=false;try{await client.chat.completions.create({model:'dummy',messages:[{role:'user',content:'hi'}]});}"
+        "catch(err){threw=true;assert.equal(err.status,status);const body=err.error??err;assert.deepEqual(body,payload.error??payload);}"
+        "assert.ok(threw,'expected API error');await agent.close();}})().then(()=>setGlobalDispatcher(new Agent())).catch(err=>{console.error(err);process.exit(1);});"
+    )
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(result.stderr or result.stdout)


### PR DESCRIPTION
## Summary
- add helper to build OpenAI-style error payloads and ensure unauthorized responses reuse it
- return error codes with sync chat failures to align with SDK expectations
- add Python and Node OpenAI SDK smoke tests that assert orchestrator errors raise

## Testing
- pytest tests/test_server_routes.py -k error -q
- pytest tests/test_sdk_error_compat.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f659b616d483218d90711e78f025a8