### PR TITLE
Handle missing guard during chat routing

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -496,12 +496,30 @@ async def chat_completions(req: Request, body: ChatRequest):
     abort_error_type: str | None = None
     abort_retry_after: int | None = None
     for provider_name in [route.primary] + route.fallback:
-        prov = providers.get(provider_name)
-        guard = guards.get(provider_name)
+        try:
+            prov = providers.get(provider_name)
+        except KeyError:
+            planner.record_failure(provider_name)
+            last_provider = provider_name
+            last_model = body.model
+            last_err = f"provider '{provider_name}' unavailable"
+            last_error_type = "routing_error"
+            continue
+        try:
+            guard = guards.get(provider_name)
+        except KeyError:
+            guard = None
+        except Exception:
+            planner.record_failure(provider_name)
+            last_provider = provider_name
+            last_model = prov.model or body.model
+            last_err = f"guard unavailable for provider '{provider_name}'"
+            last_error_type = "routing_error"
+            continue
         for attempt in range(1, MAX_PROVIDER_ATTEMPTS + 1):
             should_abort = False
-            async with guard.acquire(
-                estimated_prompt_tokens=estimated_prompt_tokens
+            async with _guard_context(
+                guard, estimated_prompt_tokens=estimated_prompt_tokens
             ) as lease:
                 attempt_count += 1
                 try:
@@ -511,7 +529,11 @@ async def chat_completions(req: Request, body: ChatRequest):
                         **provider_kwargs,
                     )
                 except Exception as exc:
-                    if getattr(guard, "_tpm_bucket", None) is not None:
+                    if (
+                        guard is not None
+                        and lease is not None
+                        and getattr(guard, "_tpm_bucket", None) is not None
+                    ):
                         guard.record_usage(
                             lease,
                             usage_prompt_tokens=0,
@@ -556,11 +578,12 @@ async def chat_completions(req: Request, body: ChatRequest):
                     latency_ms = int((time.perf_counter() - start) * 1000)
                     usage_prompt = resp.usage_prompt_tokens or 0
                     usage_completion = resp.usage_completion_tokens or 0
-                    guard.record_usage(
-                        lease,
-                        usage_prompt_tokens=usage_prompt,
-                        usage_completion_tokens=usage_completion,
-                    )
+                    if guard is not None and lease is not None:
+                        guard.record_usage(
+                            lease,
+                            usage_prompt_tokens=usage_prompt,
+                            usage_completion_tokens=usage_completion,
+                        )
                     planner.record_success(provider_name)
                     success_response = resp
                     last_provider = provider_name
@@ -790,7 +813,17 @@ async def _stream_chat_response(
 
     for provider_name in providers_to_try:
         attempts += 1
-        provider = providers.get(provider_name)
+        try:
+            provider = providers.get(provider_name)
+        except KeyError:
+            planner.record_failure(provider_name)
+            last_provider = provider_name
+            last_model = model
+            last_error = f"provider '{provider_name}' unavailable"
+            last_error_type = "routing_error"
+            last_status = BAD_GATEWAY_STATUS
+            last_retry_after = None
+            continue
         provider_model = provider.model or model
         if not hasattr(provider, "chat_stream"):
             planner.record_failure(provider_name)
@@ -820,6 +853,15 @@ async def _stream_chat_response(
             guard = guards.get(provider_name)
         except KeyError:
             guard = None
+        except Exception:
+            planner.record_failure(provider_name)
+            last_provider = provider_name
+            last_model = provider_model
+            last_error = f"guard unavailable for provider '{provider_name}'"
+            last_error_type = "routing_error"
+            last_status = BAD_GATEWAY_STATUS
+            last_retry_after = None
+            continue
         queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
         usage_prompt_tokens = usage_completion_tokens = 0
         usage_recorded = False
@@ -840,7 +882,8 @@ async def _stream_chat_response(
             if isinstance(completion_value, int) and completion_value > usage_completion_tokens:
                 usage_completion_tokens = completion_value
             if (
-                guard_lease is not None
+                guard is not None
+                and guard_lease is not None
                 and not usage_recorded
                 and (isinstance(prompt_value, int) or isinstance(completion_value, int))
             ):
@@ -880,15 +923,24 @@ async def _stream_chat_response(
             await _log_metrics(record)
 
         async def producer() -> None:
-            nonlocal guard_lease
+            nonlocal usage_prompt_tokens, usage_completion_tokens, usage_recorded, guard_lease
             try:
-                async with guard as lease:
+                async with _guard_context(
+                    guard, estimated_prompt_tokens=estimated_prompt_tokens
+                ) as lease:
                     guard_lease = lease
-                    stream_iter = provider.chat_stream(
-                        model,
-                        normalized_messages,
-                        **provider_kwargs,
-                    )
+                    try:
+                        stream_iter = provider.chat_stream(
+                            model,
+                            normalized_messages,
+                            **provider_kwargs,
+                        )
+                    except TypeError:
+                        stream_iter = provider.chat_stream(
+                            model,
+                            normalized_messages,
+                            provider_kwargs,
+                        )
                     try:
                         first_event = await anext(stream_iter, None)
                     except UnsupportedContentBlockError as exc:


### PR DESCRIPTION
## Summary
- ensure non-stream chat requests acquire guard leases through the shared helper and skip usage recording when no guard is configured
- add a regression test for missing guards and align metrics-focused tests with single-provider configurations to avoid invalid routes

## Testing
- pytest tests/test_server_routes.py::test_chat_handles_missing_guard -q
- pytest tests/test_server_routes.py::test_chat_metrics_records_response_model_when_provider_model_missing -q
- pytest tests/test_server_routes.py::test_chat_metrics_records_request_model_on_failure_when_provider_model_missing -q
- pytest tests/test_server_routes.py::test_chat_metrics_provider_error_includes_req_id tests/test_server_routes.py::test_chat_metrics_provider_error_usage_zero tests/test_server_routes.py::test_chat_metrics_provider_error_records_status_502 -q
- pytest tests/test_server_routes.py::test_chat_metrics_records_status_bad_gateway_on_total_failure -q
- pytest tests/test_server_routes.py::test_chat_metrics_records_model_precedence -q
- pytest tests/test_server_routes.py::test_chat_stream_guard_uses_prompt_estimate_and_cancels_reservation -q
- pytest tests/test_server_streaming_events.py::test_streaming_emits_without_guard -q
- pytest tests/test_server_routes.py -k metrics -q

------
https://chatgpt.com/codex/tasks/task_e_68f66c43572c83219e160087955eeee7