### PR TITLE
Handle guard-less streaming usage accounting

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -938,7 +938,8 @@ async def _stream_chat_response(
             if isinstance(completion_value, int) and completion_value > usage_completion_tokens:
                 usage_completion_tokens = completion_value
             if (
-                guard_lease is not None
+                guard is not None
+                and guard_lease is not None
                 and not usage_recorded
                 and (isinstance(prompt_value, int) or isinstance(completion_value, int))
             ):


### PR DESCRIPTION
## Summary
- ensure streaming usage accounting only records when a guard lease exists

## Testing
- pytest tests/test_server_routes.py::test_chat_stream_guard_uses_prompt_estimate_and_cancels_reservation tests/test_server_streaming_events.py::test_streaming_emits_without_guard

------
https://chatgpt.com/codex/tasks/task_e_68f676fc081483218278e48eba3cef6c