### PR TITLE
Guard fallback after max provider attempts

### DIFF
--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -670,7 +670,7 @@ def test_chat_releases_guard_usage_on_provider_exception(
     assert bucket._total == 0
 
 
-def test_chat_failure_response_includes_orch_headers_after_fallback(
+def test_chat_failure_response_includes_orch_headers_when_guard_blocks_fallback(
     route_test_config: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     app = load_app("1")
@@ -687,9 +687,10 @@ def test_chat_failure_response_includes_orch_headers_after_fallback(
     route = SimpleNamespace(primary="primary", fallback=["fallback"])
     monkeypatch.setattr(server_module.planner, "plan", lambda _task, *, sticky_key=None: route)
 
-    failure = AsyncMock(side_effect=RuntimeError("boom"))
-    primary_provider = SimpleNamespace(model="primary-model", chat=failure)
-    fallback_provider = SimpleNamespace(model="fallback-model", chat=failure)
+    primary_failure = AsyncMock(side_effect=RuntimeError("boom"))
+    fallback_failure = AsyncMock(side_effect=RuntimeError("boom"))
+    primary_provider = SimpleNamespace(model="primary-model", chat=primary_failure)
+    fallback_provider = SimpleNamespace(model="fallback-model", chat=fallback_failure)
     monkeypatch.setitem(server_module.providers.providers, "primary", primary_provider)
     monkeypatch.setitem(server_module.providers.providers, "fallback", fallback_provider)
 
@@ -700,7 +701,8 @@ def test_chat_failure_response_includes_orch_headers_after_fallback(
     )
 
     assert response.status_code == 502
-    assert_orch_headers(response, provider="fallback", fallback_attempts="1")
+    assert_orch_headers(response, provider="primary", fallback_attempts="0")
+    assert fallback_failure.call_count == 0
 
 
 def test_chat_failure_response_includes_headers_for_unroutable_task(


### PR DESCRIPTION
## Summary
- stop iterating over fallback providers once the configured maximum number of attempts has been reached
- ensure retry backoff and metrics respect the global attempt budget
- update non-stream fallback test expectations to cover the guard behaviour

## Testing
- pytest tests/test_server_routes.py::test_chat_releases_guard_usage_on_provider_exception tests/test_server_routes.py::test_chat_metrics_provider_error_includes_req_id tests/test_server_routes.py::test_chat_failure_response_includes_orch_headers_when_guard_blocks_fallback tests/test_server_routes.py::test_chat_stream_fallback_chain_returns_final_failure -q

------
https://chatgpt.com/codex/tasks/task_e_68f676fe7b6483219f45d8cc3dde84bb