### PR TITLE
Add Helm chart and template lint test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,32 @@ curl -s -H "Content-Type: application/json" \
   http://localhost:31001/v1/chat/completions | jq .
 ```
 
+## Helm でのデプロイ
+
+Kubernetes へデプロイする場合は、リポジトリ内の Helm チャート `charts/llm-orch/` を使用できます。
+
+1. デフォルト値をコピーして環境に合わせて調整します。
+
+   ```bash
+   cp charts/llm-orch/values.yaml my-values.yaml
+   ```
+
+2. `my-values.yaml` の `config.providers` / `config.router` に `config/providers.toml` と `config/router.yaml` 相当の内容を埋め込みます。
+   - `config.providers` は TOML のリテラルをそのまま貼り付けます。
+   - `config.router` は YAML のリテラルをそのまま貼り付けます。
+
+3. 下記いずれかの方法でマニフェストを生成または適用します。
+
+   ```bash
+   # マニフェストを確認
+   helm template llm-orch charts/llm-orch -f my-values.yaml
+
+   # クラスタへ適用
+   helm upgrade --install llm-orch charts/llm-orch -f my-values.yaml
+   ```
+
+`helm template` / `helm upgrade` 実行時に ConfigMap が生成され、`ORCH_CONFIG_DIR=/config` として Pod にマウントされます。プロバイダの認証情報は引き続き環境変数（例: `OPENAI_API_KEY`）で注入してください。
+
 ## 設定
 
 - `config/providers.toml` : プロバイダ定義（`type` / `base_url` / `model` / `auth_env` / `rpm` / `tpm` / `concurrency`）

--- a/charts/llm-orch/Chart.yaml
+++ b/charts/llm-orch/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: llm-orch
+description: Helm chart for deploying llm-orch
+icon: https://raw.githubusercontent.com/zen-xu/llm-orch/main/docs/assets/logo.png
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/llm-orch/templates/llm-orch.yaml
+++ b/charts/llm-orch/templates/llm-orch.yaml
@@ -1,0 +1,92 @@
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $fullname := default (printf "%s-%s" .Release.Name $name) .Values.fullnameOverride -}}
+{{- $labels := dict "app.kubernetes.io/name" $name "app.kubernetes.io/instance" .Release.Name "app.kubernetes.io/version" .Chart.AppVersion "app.kubernetes.io/component" "server" "app.kubernetes.io/managed-by" "Helm" -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-config" $fullname | trunc 63 | trimSuffix "-" }}
+  labels:
+{{- range $key, $value := $labels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+data:
+  providers.toml: |
+{{- default "" .Values.config.providers | nindent 4 }}
+  router.yaml: |
+{{- default "" .Values.config.router | nindent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullname | trunc 63 | trimSuffix "-" }}
+  labels:
+{{- range $key, $value := $labels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $name | quote }}
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ $name | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+        app.kubernetes.io/component: "server"
+    spec:
+      containers:
+        - name: {{ $name | quote }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: ORCH_CONFIG_DIR
+              value: /config
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+{{- with .Values.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ printf "%s-config" $fullname | trunc 63 | trimSuffix "-" }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullname | trunc 63 | trimSuffix "-" }}
+  labels:
+{{- range $key, $value := $labels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ $name | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/charts/llm-orch/values.yaml
+++ b/charts/llm-orch/values.yaml
@@ -1,0 +1,32 @@
+image:
+  repository: ghcr.io/zen-xu/llm-orch
+  tag: latest
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 8000
+
+resources: {}
+
+affinity: {}
+
+tolerations: []
+
+nodeSelector: {}
+
+config:
+  providers: |
+    # See config/providers.toml for a full example
+    [providers.example]
+    transport = "openai-chat-completions"
+    model = "gpt-4o"
+
+  router: |
+    # See config/router.yaml for detailed routing examples
+    routes:
+      - name: default
+        primary: providers.example
+        fallback: []

--- a/tests/test_ci_helm_chart.py
+++ b/tests/test_ci_helm_chart.py
@@ -1,0 +1,52 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm CLI is not available")
+def test_helm_template_injects_configs(tmp_path: Path) -> None:
+    chart_dir = Path(__file__).resolve().parent.parent / "charts" / "llm-orch"
+    assert chart_dir.exists(), "Helm chart directory is missing"
+
+    values_file = tmp_path / "values.yaml"
+    values_file.write_text(
+        """
+config:
+  providers: |
+    [providers.test]
+    model = "gpt-4"
+  router: |
+    routes:
+      - name: default
+        primary: providers.test
+        fallback: []
+""".strip()
+    )
+
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "llm-orch",
+            str(chart_dir),
+            "-f",
+            str(values_file),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    sanitized_lines = [
+        line
+        for line in result.stdout.splitlines()
+        if not line.startswith("# Source:")
+    ]
+    rendered = "\n".join(sanitized_lines)
+
+    assert "providers.toml: |" in rendered
+    assert "router.yaml: |" in rendered
+    assert "model = \"gpt-4\"" in rendered
+    assert "primary: providers.test" in rendered


### PR DESCRIPTION
## Summary
- add a Helm chart for llm-orch with config injection for providers and router
- document Helm-based deployment steps
- add a CI-oriented pytest that templates the chart and sanitizes the output

## Testing
- pytest tests/test_ci_helm_chart.py

------
https://chatgpt.com/codex/tasks/task_e_68f68de354148321b787a68634ead8d0