### PR TITLE
Add error code enum and document standard error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ curl -s -H "Content-Type: application/json" \
 
 - すべての `/v1/chat/completions` 応答（成功・エラー・SSE）で `x-orch-request-id` / `x-orch-provider` / `x-orch-fallback-attempts` を返却します。フォールバックが発生した場合は試行回数に応じて `x-orch-fallback-attempts` が加算されます。
 
+## エラーコード
+
+| HTTPステータス | `error.code`                | 意味                             |
+|----------------|-----------------------------|----------------------------------|
+| 401            | `invalid_api_key`            | APIキー認証に失敗                 |
+| 429            | `rate_limit`                 | プロバイダまたはガードのレート制限 |
+| 5xx/BadGateway | `provider_server_error`      | プロバイダ側のサーバエラー         |
+| 4xxその他      | `provider_error` / `routing_error` | プロバイダ起因の再試行不可エラー |
+
+> 互換性: 既存クライアントは引き続き `error.type` を信頼できますが、`error.code` は上表の列挙値のみを前提に実装してください。
+
 ## ホットリロード
 
 - `_config_refresh_loop` が `ORCH_CONFIG_DIR` 配下の `providers.toml` / `router.yaml` を監視し、更新検知時に `reload_configuration()` を経由して `RoutePlanner` / `ProviderRegistry` / `ProviderGuards` を再構築します。


### PR DESCRIPTION
## Summary
- introduce an `ErrorCode` enum in the server and centralize error code resolution
- add a server route test that ensures representative responses emit enumerated error codes
- document the supported error codes and a compatibility note in the README

## Testing
- pytest tests/test_server_routes.py -k error_code_is_enumerated

------
https://chatgpt.com/codex/tasks/task_e_68f68ddfcfb083219c481028a2314162