### PR TITLE
Log warning when inbound API keys are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ curl -s -H "Content-Type: application/json" \
 - `ORCH_METRICS_EXPORT_MODE` : メトリクス出力モード。`prom`（Prometheusのみ）/`otel`（OTelのみ）/`both`（両方）。既定は `prom`。後方互換として `ORCH_OTEL_METRICS_EXPORT` を真値にすると `both` 相当になります。
 - `ORCH_OTEL_METRICS_EXPORT` : OpenTelemetryメトリクスを旧来通り有効化する互換フラグ。`ORCH_METRICS_EXPORT_MODE` 未設定時のみ参照されます。
 
+## セキュリティ
+
+- 本番環境では `ORCH_INBOUND_API_KEYS` によるAPIキー保護を必須運用とし、キー未設定時はアプリケーションログに警告が出力されることを監視してください。
+- 既定の `ORCH_CORS_ALLOW_ORIGINS` は空文字列（=許可Originなし）であり、必要なOriginのみを明示的に列挙してください。
+- APIキー値など機密情報はレスポンスやHTTPヘッダに含めず、ログにも平文で記録されません。APIキー保護を無効化した場合のみ警告ログが出力されます。
+
 ## メトリクス
 
 - 既定は `metrics/requests-YYYYMMDD.jsonl` に 1リクエスト=1行追記。

--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import json
+import logging
 import os
 import time
 import uuid
@@ -75,6 +76,8 @@ API_KEY_HEADER = os.environ.get("ORCH_API_KEY_HEADER", "x-api-key")
 ALLOWED_ORIGINS = _parse_env_list(os.environ.get("ORCH_CORS_ALLOW_ORIGINS", ""))
 PROM_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 HISTOGRAM_BUCKETS: tuple[float, ...] = (0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0)
+
+logger = logging.getLogger(__name__)
 
 
 def _new_histogram_state() -> dict[str, Any]:
@@ -373,6 +376,9 @@ def _make_error_body(
 
 def _require_api_key(req: Request) -> None:
     if not INBOUND_API_KEYS:
+        logger.warning(
+            "APIキー保護が無効: ORCH_INBOUND_API_KEYS が未設定"
+        )
         return
     candidate = req.headers.get(API_KEY_HEADER)
     if candidate is None:

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 import os
 import sys
 from collections.abc import Callable
@@ -1266,6 +1267,21 @@ def test_chat_requires_api_key_when_configured(
         },
     )
     assert response.status_code == 401
+
+
+def test_logs_warning_when_api_key_not_configured(
+    route_test_config: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("ORCH_INBOUND_API_KEYS", "")
+    monkeypatch.setenv("ORCH_CORS_ALLOW_ORIGINS", "")
+    with caplog.at_level(logging.WARNING):
+        app = load_app("1")
+        client = TestClient(app)
+        response = client.get("/metrics")
+
+    assert response.status_code == 200
+    warnings = [record.getMessage() for record in caplog.records if record.levelno == logging.WARNING]
+    assert any("APIキー保護が無効" in message for message in warnings)
 
 def test_chat_accepts_tool_choice_strings(
     route_test_config: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- log a warning when inbound API key enforcement is disabled and avoid exposing sensitive values
- add a regression test that asserts the warning is emitted when no API keys are configured
- document API key, CORS, and logging expectations in the security section of the README

## Testing
- pytest tests/test_server_routes.py::test_logs_warning_when_api_key_not_configured


------
https://chatgpt.com/codex/tasks/task_e_68f68dd8c4548321981cd45ad001eec1