### PR TITLE
Update README streaming docs examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,17 @@ client = OpenAI(base_url="http://localhost:31001/v1", api_key="sk-local-1")
 with client.chat.completions.stream(
     model="gpt-4o-mini",
     messages=[
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "SSEで自己紹介を短く返して。"},
+        {
+            "role": "system",
+            "content": "You summarize patch notes in friendly Japanese.",
+        },
+        {
+            "role": "user",
+            "content": "以下のdiffを要約して: add webhook retry metric",
+        },
     ],
-    temperature=0.7,
-    max_tokens=256,
+    temperature=0.6,
+    max_tokens=192,
 ) as stream:
     for event in stream:
         if event.type == "response.output_text.delta":
@@ -159,11 +165,17 @@ with client.chat.completions.stream(
 {
   "model": "gpt-4o-mini",
   "messages": [
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "SSEで自己紹介を短く返して。"}
+    {
+      "role": "system",
+      "content": "You summarize patch notes in friendly Japanese."
+    },
+    {
+      "role": "user",
+      "content": "以下のdiffを要約して: add webhook retry metric"
+    }
   ],
-  "temperature": 0.7,
-  "max_tokens": 256,
+  "temperature": 0.6,
+  "max_tokens": 192,
   "stream": true
 }
 ```
@@ -181,11 +193,17 @@ const client = new OpenAI({
 const stream = await client.chat.completions.stream({
   model: "gpt-4o-mini",
   messages: [
-    { role: "system", content: "You respond with JSON fragments." },
-    { role: "user", content: "進捗報告テンプレートをストリームで送って。" },
+    {
+      role: "system",
+      content: "You emit status updates as JSON fragments.",
+    },
+    {
+      role: "user",
+      content: "スプリント3の進捗レポート雛形をストリームで。",
+    },
   ],
-  temperature: 0.5,
-  max_tokens: 200,
+  temperature: 0.4,
+  max_tokens: 220,
 });
 
 for await (const event of stream) {
@@ -201,11 +219,17 @@ process.stdout.write("\n");
 {
   "model": "gpt-4o-mini",
   "messages": [
-    {"role": "system", "content": "You respond with JSON fragments."},
-    {"role": "user", "content": "進捗報告テンプレートをストリームで送って。"}
+    {
+      "role": "system",
+      "content": "You emit status updates as JSON fragments."
+    },
+    {
+      "role": "user",
+      "content": "スプリント3の進捗レポート雛形をストリームで。"
+    }
   ],
-  "temperature": 0.5,
-  "max_tokens": 200,
+  "temperature": 0.4,
+  "max_tokens": 220,
   "stream": true
 }
 ```
@@ -239,14 +263,21 @@ process.stdout.write("\n");
 ```bash
 curl -N http://localhost:31001/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "X-Orch-Session: checkout-42" \
+  -H "X-Orch-Sticky-Key: checkout-42" \
   -d '{
         "model": "gpt-4o-mini",
         "messages": [
-          {"role": "system", "content": "You are a routing assistant."},
-          {"role": "user", "content": "最新レコメンドの候補を3つ提案して。"}
+          {
+            "role": "system",
+            "content": "You triage loyalty checkout recommendations."
+          },
+          {
+            "role": "user",
+            "content": "カート checkout-42 に向けたレコメンドを3件まとめて。"
+          }
         ],
-        "temperature": 0.3,
+        "temperature": 0.2,
+        "max_tokens": 512,
         "stream": false
       }'
 ```
@@ -256,10 +287,17 @@ curl -N http://localhost:31001/v1/chat/completions \
 {
   "model": "gpt-4o-mini",
   "messages": [
-    {"role": "system", "content": "You are a routing assistant."},
-    {"role": "user", "content": "最新レコメンドの候補を3つ提案して。"}
+    {
+      "role": "system",
+      "content": "You triage loyalty checkout recommendations."
+    },
+    {
+      "role": "user",
+      "content": "カート checkout-42 に向けたレコメンドを3件まとめて。"
+    }
   ],
-  "temperature": 0.3,
+  "temperature": 0.2,
+  "max_tokens": 512,
   "stream": false
 }
 ```

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -51,39 +51,49 @@ def expected_readme_examples() -> Dict[str, Dict[str, Any]]:
         "ChatRequestStickyCurl": {
             "model": "gpt-4o-mini",
             "messages": [
-                {"role": "system", "content": "You are a routing assistant."},
+                {
+                    "role": "system",
+                    "content": "You triage loyalty checkout recommendations.",
+                },
                 {
                     "role": "user",
-                    "content": "最新レコメンドの候補を3つ提案して。",
+                    "content": "カート checkout-42 に向けたレコメンドを3件まとめて。",
                 },
             ],
-            "temperature": 0.3,
+            "temperature": 0.2,
+            "max_tokens": 512,
             "stream": False,
         },
         "ChatRequestStreamPython": {
             "model": "gpt-4o-mini",
             "messages": [
-                {"role": "system", "content": "You are a helpful assistant."},
+                {
+                    "role": "system",
+                    "content": "You summarize patch notes in friendly Japanese.",
+                },
                 {
                     "role": "user",
-                    "content": "SSEで自己紹介を短く返して。",
+                    "content": "以下のdiffを要約して: add webhook retry metric",
                 },
             ],
-            "temperature": 0.7,
-            "max_tokens": 256,
+            "temperature": 0.6,
+            "max_tokens": 192,
             "stream": True,
         },
         "ChatRequestStreamJavaScript": {
             "model": "gpt-4o-mini",
             "messages": [
-                {"role": "system", "content": "You respond with JSON fragments."},
+                {
+                    "role": "system",
+                    "content": "You emit status updates as JSON fragments.",
+                },
                 {
                     "role": "user",
-                    "content": "進捗報告テンプレートをストリームで送って。",
+                    "content": "スプリント3の進捗レポート雛形をストリームで。",
                 },
             ],
-            "temperature": 0.5,
-            "max_tokens": 200,
+            "temperature": 0.4,
+            "max_tokens": 220,
             "stream": True,
         },
     }


### PR DESCRIPTION
## Summary
- add explicit fixtures for sticky and streaming README schema blocks in tests
- refresh README sticky header curl and SDK streaming examples with matching schema JSON

## Testing
- `pytest tests/test_docs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68f73ca62fb48321b123841d76b28353