### PR TITLE
Ensure /v1/models exposes expected model metadata

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -566,7 +566,7 @@ STREAMING_UNSUPPORTED_ERROR = "streaming responses are not supported"
 
 @app.get("/v1/models", response_model=ModelListResponse)
 async def list_models() -> ModelListResponse:
-    alias_map = _build_alias_map(cfg.providers) if USE_DUMMY else {}
+    alias_map = _build_alias_map(cfg.providers)
     alias_groups: dict[str, list[str]] = {}
     for alias, canonical in alias_map.items():
         alias_groups.setdefault(canonical, []).append(alias)

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -121,6 +121,7 @@ def test_models_endpoint_returns_expected_shape(route_test_config: Path) -> None
     assert dummy_entry["id"] == "dummy"
     assert dummy_entry["object"] == "model"
     assert dummy_entry["owned_by"] == "dummy"
+    assert dummy_entry["model"] == "dummy"
     assert "dummy_alt" in dummy_entry.get("aliases", [])
 
 


### PR DESCRIPTION
## Summary
- verify the /v1/models response includes the model identifier for each entry
- build the model alias map for all configurations so the response stays consistent

## Testing
- pytest tests/test_server_routes.py::test_models_endpoint_returns_expected_shape

------
https://chatgpt.com/codex/tasks/task_e_68f73ca4e5708321913752df2b5987b5