### PR TITLE
Fix ruff E402 warnings in streaming failover test

### DIFF
--- a/tests/test_server_streaming_failover.py
+++ b/tests/test_server_streaming_failover.py
@@ -11,12 +11,12 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
-from src.orch.router import RouteDef, RouteTarget
+from src.orch.router import RouteDef, RouteTarget  # noqa: E402
 
-from tests.test_server_routes import load_app
-from tests.test_server_streaming_routing import (
+from tests.test_server_routes import load_app  # noqa: E402
+from tests.test_server_streaming_routing import (  # noqa: E402
     _DummyGuard,
     _Registry,
     _http_status_error,


### PR DESCRIPTION
## Summary
- silence E402 lint warnings in the streaming failover test by marking imports that follow the sys.path setup

## Testing
- ruff check tests/test_server_streaming_failover.py

------
https://chatgpt.com/codex/tasks/task_e_68f73ea3e0b483219f55fc80d603846d