### PR TITLE
fix: dedupe python tool requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,10 @@
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
 httpx==0.27.2
-mypy==1.11.2
 pydantic==2.9.2
 pyyaml==6.0.2
-ruff==0.6.8
+ruff==0.6.9
 tenacity==9.0.0
 tomli==2.0.1; python_version < '3.11'
 pytest==8.3.3
-ruff==0.6.9
 mypy==1.13.0


### PR DESCRIPTION
## Summary
- remove the duplicate ruff and mypy pins in requirements.txt so pip can resolve dependencies

## Testing
- `. .venv/bin/activate && pip install -r requirements.txt` *(fails: ProxyError Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68f74528e2e4832199973d6f300e99f4