### PR TITLE
Remove unused imports from server config reload test

### DIFF
--- a/tests/test_server_config_reload.py
+++ b/tests/test_server_config_reload.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import os
 import sys
 import time
 from pathlib import Path
 from threading import Event
-from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary
- drop unused `os` and `SimpleNamespace` imports from `tests/test_server_config_reload.py`

## Testing
- ruff check tests/test_server_config_reload.py

------
https://chatgpt.com/codex/tasks/task_e_68f74ffc9a84832180aa3fec0d05039b