### PR TITLE
Deduplicate mypy and ruff pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-- `requirements.txt` の `ruff` と `mypy` を重複解消し、最新バージョン（`ruff==0.6.9`, `mypy==1.13.0`）に統一。
+- `requirements.txt` の `ruff` / `mypy` の重複行を整理し、CI 用ツールとして単一バージョン（`ruff==0.6.9`, `mypy==1.13.0`）に固定。
 
 ## v0.1.0 - 2024-01-01
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
 httpx==0.27.2
+
+# Developer tooling (deduplicated to a single pinned version)
 mypy==1.13.0
+ruff==0.6.9
+
 pydantic==2.9.2
 pyyaml==6.0.2
-ruff==0.6.9
 tenacity==9.0.0
 tomli==2.0.1; python_version < '3.11'
 pytest==8.3.3


### PR DESCRIPTION
## Summary
- group the mypy and ruff requirements under a tooling section so only one pinned entry remains for each tool
- document the reasoning for keeping the single versions in the changelog

## Testing
- pytest tests/test_ci_smoke.py::test_requirements_file_has_unique_packages -q

------
https://chatgpt.com/codex/tasks/task_e_68f7542424c08321886f9104e343c6f7