### PR TITLE
Clarify /v1/models response metadata docs

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -218,6 +218,7 @@ def _apply_provider_aliases(
 
 
 class ModelInfo(BaseModel):
+    """Model metadata entry with canonical identifiers and alias information."""
     id: str
     object: Literal["model"] = "model"
     owned_by: str
@@ -227,6 +228,7 @@ class ModelInfo(BaseModel):
 
 
 class ModelListResponse(BaseModel):
+    """Response envelope for `/v1/models` exposing :class:`ModelInfo` entries."""
     object: Literal["list"] = "list"
     data: list[ModelInfo]
 


### PR DESCRIPTION
## Summary
- document the Pydantic models backing `/v1/models` to reflect the canonical provider/model/alias fields

## Testing
- pytest tests/test_server_routes.py::test_models_endpoint_returns_expected_shape -q

------
https://chatgpt.com/codex/tasks/task_e_68f7541a31888321aeab17b04d1c5800