### PR TITLE
Fix ruff import issues across test suite

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -3,14 +3,8 @@ from __future__ import annotations
 
 import json
 import re
-import sys
 from pathlib import Path
 from typing import Any, Dict, Iterator, Tuple
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
 
 import pytest
 

--- a/tests/test_metrics_logger.py
+++ b/tests/test_metrics_logger.py
@@ -7,9 +7,7 @@ from typing import Any, Dict, Iterable, List, Tuple
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
+from src.orch.metrics import MetricsLogger
 
 
 def _install_otel_stub() -> None:
@@ -178,8 +176,6 @@ try:  # pragma: no cover - executed during import
 except ModuleNotFoundError:  # pragma: no cover - fallback for test environment
     _install_otel_stub()
     from opentelemetry.sdk.metrics.export import InMemoryMetricReader  # type: ignore[assignment]
-
-from src.orch.metrics import MetricsLogger
 
 
 def _sample_record() -> dict[str, Any]:

--- a/tests/test_providers_anthropic.py
+++ b/tests/test_providers_anthropic.py
@@ -1,18 +1,12 @@
 import asyncio
 import json
-import sys
 from dataclasses import asdict
-from pathlib import Path
 from typing import Any, AsyncIterator, cast
 
 import httpx
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
-
-from src.orch.providers import AnthropicProvider, BaseProvider, ProviderStreamChunk
+from src.orch.providers import AnthropicProvider, ProviderStreamChunk
 from src.orch.router import ProviderDef
 from src.orch.types import ProviderChatResponse, chat_response_from_provider
 
@@ -489,7 +483,9 @@ def test_anthropic_payload_maps_function_call_message(
     ]
 
 
-def test_anthropic_payload_maps_tool_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_anthropic_payload_maps_tool_messages_text_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     provider = build_anthropic_provider(monkeypatch)
     tool_content = [{"type": "output_text", "text": "done"}]
     messages: list[dict[str, Any]] = [
@@ -848,18 +844,6 @@ def test_anthropic_payload_maps_tool_messages(monkeypatch: pytest.MonkeyPatch) -
         },
         {"role": "assistant", "content": [{"type": "text", "text": "done"}]},
     ]
-
-
-def test_anthropic_payload_errors_on_tool_without_id(monkeypatch: pytest.MonkeyPatch) -> None:
-    provider = build_anthropic_provider(monkeypatch)
-
-    messages: list[dict[str, Any]] = [
-        {"role": "user", "content": "hello"},
-        {"role": "tool", "content": "result"},
-    ]
-
-    with pytest.raises(ValueError, match="tool_call_id"):
-        run_chat(provider, monkeypatch, messages)
 
 
 def test_anthropic_chat_maps_tool_use_stop_reason(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -1,24 +1,18 @@
 import asyncio
-import sys
 from collections.abc import AsyncGenerator
-from pathlib import Path
 from typing import Any, TypedDict
 
 import httpx
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
-
-from src.orch.providers import OpenAICompatProvider  # noqa: E402
-from src.orch.router import ProviderDef  # noqa: E402
+from src.orch.providers import OpenAICompatProvider
+from src.orch.router import ProviderDef
 from src.orch.types import (
     ProviderChatResponse,
     ProviderStreamChunk as ProviderStreamChunkModel,
     chat_response_from_provider,
     provider_chat_response_from_stream,
-)  # noqa: E402
+)
 
 
 class ProviderStreamChunkDict(TypedDict, total=False):
@@ -214,11 +208,14 @@ def test_provider_chat_response_from_stream_merges_chunks() -> None:
     ]
 
     provider_response = provider_chat_response_from_stream("gpt-4o", chunks)
-    assert provider_response.model == "gpt-4o"; assert provider_response.finish_reason == "stop"
-    assert provider_response.usage_prompt_tokens == 5; assert provider_response.usage_completion_tokens == 7
+    assert provider_response.model == "gpt-4o"
+    assert provider_response.finish_reason == "stop"
+    assert provider_response.usage_prompt_tokens == 5
+    assert provider_response.usage_completion_tokens == 7
 
     payload = chat_response_from_provider(provider_response)
-    assert payload["choices"][0]["message"]["content"] == "Hello world"; assert payload["choices"][0]["finish_reason"] == "stop"
+    assert payload["choices"][0]["message"]["content"] == "Hello world"
+    assert payload["choices"][0]["finish_reason"] == "stop"
     assert payload["usage"] == {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}
 
 

--- a/tests/test_providers_openai_compat.py
+++ b/tests/test_providers_openai_compat.py
@@ -1,14 +1,8 @@
 import asyncio
-import sys
-from pathlib import Path
 from typing import Any, cast
 
 import httpx
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.orch.providers import OpenAICompatProvider
 from src.orch.router import ProviderDef

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,11 +1,4 @@
-import sys
-from pathlib import Path
-
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-  sys.path.insert(0, str(PROJECT_ROOT))
 
 import src.orch.rate_limiter as rate_limiter
 from src.orch.rate_limiter import Guard

--- a/tests/test_router_config.py
+++ b/tests/test_router_config.py
@@ -1,15 +1,11 @@
 import builtins
-import sys
-import types
 import importlib
 import random
+import sys
+import types
 from pathlib import Path
 
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.orch.router import RoutePlanner, load_config
 from src.orch.providers import ProviderRegistry

--- a/tests/test_scripts_analyze.py
+++ b/tests/test_scripts_analyze.py
@@ -1,10 +1,4 @@
 import json
-import sys
-from pathlib import Path
-
-ROOT_DIR = Path(__file__).resolve().parents[1]
-if str(ROOT_DIR) not in sys.path:
-    sys.path.insert(0, str(ROOT_DIR))
 
 import scripts.analyze as analyze
 

--- a/tests/test_scripts_export_pytest_junit.py
+++ b/tests/test_scripts_export_pytest_junit.py
@@ -328,7 +328,7 @@ def test_convert_junit_to_jsonl_handles_nested_testsuites(tmp_path: Path) -> Non
     ]
 
 
-def test_convert_junit_to_jsonl_handles_default_namespace(tmp_path: Path) -> None:
+def test_convert_junit_to_jsonl_handles_custom_namespace(tmp_path: Path) -> None:
     xml_path = tmp_path / "pytest.xml"
     output_path = tmp_path / "out.jsonl"
     write_file(

--- a/tests/test_sdk_error_compat.py
+++ b/tests/test_sdk_error_compat.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import json, shutil, subprocess, sys
-from pathlib import Path
+import json
+import shutil
+import subprocess
 from typing import Any
 
-import httpx, pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
+import httpx
+import pytest
 
 from src.orch import server as orch_server
 


### PR DESCRIPTION
## Summary
- remove ad-hoc sys.path mutations from tests and normalize import groupings
- rename or consolidate duplicate test cases flagged by ruff
- clean up stylistic violations such as chained assertions to satisfy linting

## Testing
- ruff check tests

------
https://chatgpt.com/codex/tasks/task_e_68f75a90f8c08321b5c14aab432b6f3e