### PR TITLE
Include alias providers in models listing

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -576,12 +576,11 @@ async def list_models() -> ModelListResponse:
 
     models: list[ModelInfo] = []
     for name, provider_def in sorted(cfg.providers.items()):
-        if name in alias_map:
-            continue
         alias_list = sorted(alias_groups.get(name, ()))
+        model_id = name if name in alias_map else provider_def.model or name
         models.append(
             ModelInfo(
-                id=provider_def.model or name,
+                id=model_id,
                 owned_by=provider_def.type,
                 provider=name,
                 model=provider_def.model,

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -1337,8 +1337,11 @@ def test_models_endpoint_lists_configured_providers(route_test_config: Path) -> 
         assert item["object"] == "model"
         assert isinstance(item["owned_by"], str)
         assert item["owned_by"]
-    ids = {item["id"] for item in data}
-    assert {"dummy", "dummy_alt"}.issubset(ids)
+    dummy_alt_entry = next(
+        (item for item in data if item["provider"] == "dummy_alt" and item["id"] == "dummy_alt"),
+        None,
+    )
+    assert dummy_alt_entry is not None
 
 
 def test_chat_requires_api_key_when_configured(


### PR DESCRIPTION
## Summary
- ensure the models endpoint returns entries for alias providers while still surfacing canonical alias metadata
- tighten the models endpoint test to assert the dummy_alt alias is listed explicitly

## Testing
- pytest tests/test_server_routes.py::test_models_endpoint_lists_configured_providers -q *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68f75cc6e060832183c3f7a48de64efa