### PR TITLE
Add Apache licensing notices for workflow cookbook

### DIFF
--- a/workflow-cookbook-main/NOTICE
+++ b/workflow-cookbook-main/NOTICE
@@ -1,0 +1,10 @@
+workflow-cookbook
+Copyright (c) 2025 RNA4219
+
+This product is licensed to you under the Apache License, Version 2.0 (the "License").
+You may not use this product except in compliance with the License.
+You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
+
+This distribution includes documentation and scripts authored by RNA4219.
+If you copy files from this repository into other projects, those files remain under Apache-2.0.
+Retain this NOTICE file when distributing copies or substantial portions of the files.

--- a/workflow-cookbook-main/README.md
+++ b/workflow-cookbook-main/README.md
@@ -31,6 +31,7 @@ canary rules.
 ![lead_time_p95_hours](https://img.shields.io/badge/lead__time__p95__hours-72h-blue)
 ![mttr_p95_minutes](https://img.shields.io/badge/mttr__p95__minutes-60m-blue)
 ![change_failure_rate_max](https://img.shields.io/badge/change__failure__rate__max-0.10-blue)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 <!-- markdownlint-enable MD013 -->
 
 > バッジ値は `governance/policy.yaml` の `slo` と同期。更新時は同ファイルの値を修正し、上記3つのバッジ表示を揃える。
@@ -41,3 +42,7 @@ canary rules.
 - fix: 〜 を修正
 - chore/docs: 〜 を整備
 - semver:major/minor/patch ラベルでリリース自動分類
+
+## License
+
+Apache-2.0。特段の注記がない限り、このリポジトリから他プロジェクトへコピーしたファイルも Apache-2.0 のままです。再配布時は NOTICE の記載を保持してください。

--- a/workflow-cookbook-main/tools/ci/check_front_matter.py
+++ b/workflow-cookbook-main/tools/ci/check_front_matter.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 RNA4219
+
 from __future__ import annotations
 
 import argparse

--- a/workflow-cookbook-main/tools/ci/check_governance_gate.py
+++ b/workflow-cookbook-main/tools/ci/check_governance_gate.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 RNA4219
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- add NOTICE file for workflow-cookbook distribution
- add Apache-2.0 badge and license section to README
- add SPDX headers to workflow-cookbook tooling scripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f75fa1e1cc8321a7cb6bc7db437101