### PR TITLE
Ensure /v1/models includes alias entries

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -618,17 +618,28 @@ async def list_models() -> ModelListResponse:
 
     models: list[ModelInfo] = []
     for name, provider_def in sorted(cfg.providers.items()):
-        alias_list = sorted(alias_groups.get(name, ()))
-        model_id = name if name in alias_map else provider_def.model or name
-        models.append(
-            ModelInfo(
-                id=model_id,
-                owned_by=provider_def.type,
-                provider=name,
-                model=provider_def.model,
-                aliases=alias_list or None,
+        canonical = alias_map.get(name)
+        if canonical is None:
+            alias_list = sorted(alias_groups.get(name, ()))
+            models.append(
+                ModelInfo(
+                    id=provider_def.model or name,
+                    owned_by=provider_def.type,
+                    provider=name,
+                    model=provider_def.model,
+                    aliases=alias_list or None,
+                )
             )
-        )
+        else:
+            models.append(
+                ModelInfo(
+                    id=name,
+                    owned_by=provider_def.type,
+                    provider=name,
+                    model=provider_def.model,
+                    aliases=None,
+                )
+            )
 
     return ModelListResponse(data=models)
 


### PR DESCRIPTION
## Summary
- adjust the /v1/models handler to emit alias ModelInfo records alongside canonical providers while keeping alias lists on the canonical entries
- extend the server routes test to stub the OpenAI provider import in dummy mode and assert that the dummy alias entry is present in the response

## Testing
- pytest tests/test_server_routes.py::test_models_endpoint_lists_configured_providers -q

------
https://chatgpt.com/codex/tasks/task_e_68f7e338d69c83218b02c81f753f5df5