### PR TITLE
Fix lint issues identified by ruff

### DIFF
--- a/src/orch/providers/__init__.py
+++ b/src/orch/providers/__init__.py
@@ -4,7 +4,7 @@ import os
 from collections.abc import MutableMapping
 from dataclasses import asdict, dataclass
 from urllib.parse import urlparse, urlunparse
-from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, cast
 
 import httpx
 

--- a/src/orch/providers/openai.py
+++ b/src/orch/providers/openai.py
@@ -16,8 +16,9 @@ from ..types import (
     ProviderStreamChunk as ProviderStreamChunkModel,
 )
 
-_VALID_ROLES: frozenset[str] = frozenset({"system", "user", "assistant", "tool"})
 from . import BaseProvider
+
+_VALID_ROLES: frozenset[str] = frozenset({"system", "user", "assistant", "tool"})
 
 
 class OpenAICompatProvider(BaseProvider):

--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -12,6 +12,7 @@ from contextlib import asynccontextmanager
 from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
+from enum import Enum
 from typing import Any, Literal, cast
 
 import httpx


### PR DESCRIPTION
## Summary
- import typing.cast for Anthropic content normalization helper
- reorder OpenAI provider imports to satisfy lint ordering rules
- add the missing Enum import for the error code definition

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68f7e8f94ecc8321823986473f52cb6b