### PR TITLE
Fix mypy strict failures in providers and server

### DIFF
--- a/src/orch/providers/__init__.py
+++ b/src/orch/providers/__init__.py
@@ -12,8 +12,7 @@ from ..router import ProviderDef
 from ..types import ProviderChatResponse
 
 if TYPE_CHECKING:
-    from .openai import OpenAICompatProvider
-
+    from .openai import OpenAICompatProvider as _OpenAICompatProvider
 # [ ] openai移行完了
 
 
@@ -915,7 +914,9 @@ class DummyProvider(BaseProvider):
 
 
 _openai_module = importlib.import_module(".openai", __name__)
-OpenAICompatProvider = _openai_module.OpenAICompatProvider
+OpenAICompatProvider = cast(
+    type[BaseProvider], _openai_module.OpenAICompatProvider
+)
 
 
 class ProviderRegistry:


### PR DESCRIPTION
## Summary
- avoid reassigning imported provider class during type checking by casting the dynamically imported implementation
- normalize async anext fallback handling and canonical alias typing to satisfy mypy strict checks

## Testing
- mypy --strict src

------
https://chatgpt.com/codex/tasks/task_e_68f833ce37a08321a26e687f172ea4bf