### PR TITLE
Fix ruff lint import warnings

### DIFF
--- a/src/orch/providers/__init__.py
+++ b/src/orch/providers/__init__.py
@@ -13,6 +13,8 @@ from ..types import ProviderChatResponse
 
 if TYPE_CHECKING:
     from .openai import OpenAICompatProvider as _OpenAICompatProvider
+
+    OpenAICompatProvider = _OpenAICompatProvider
 # [ ] openai移行完了
 
 

--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -21,6 +21,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
+from .metrics import MetricsLogger
+from .providers import ProviderRegistry, UnsupportedContentBlockError
+from .rate_limiter import GuardLease, ProviderGuards
+from .router import ProviderDef, RouteDef, RoutePlanner, load_config
+from .types import ChatRequest, ProviderChatResponse, chat_response_from_provider
+
 _builtin_anext_raw = getattr(builtins, "anext", None)
 if _builtin_anext_raw is not None:
     _builtin_anext: Callable[..., Awaitable[Any]] | None = cast(
@@ -29,13 +35,6 @@ if _builtin_anext_raw is not None:
     )
 else:  # pragma: no cover - fallback retained for clarity
     _builtin_anext = None
-
-
-from .metrics import MetricsLogger
-from .providers import ProviderRegistry, UnsupportedContentBlockError
-from .rate_limiter import GuardLease, ProviderGuards
-from .router import ProviderDef, RouteDef, RoutePlanner, load_config
-from .types import ChatRequest, ProviderChatResponse, chat_response_from_provider
 
 _MISSING = object()
 


### PR DESCRIPTION
## Summary
- TYPE_CHECKING ブロックで `OpenAICompatProvider` を型エイリアスとして公開
- `src/orch/server.py` のローカルインポートをトップレベルに移動して Ruff E402 を解消

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68f88093e1c083219152c654d4ba16cb