### PR TITLE
Add pytest sys.path bootstrap for src package

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration to ensure project package importability."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ROOT_STR = str(ROOT_DIR)
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)


### PR DESCRIPTION
## Summary
- add a pytest conftest that prepends the repository root to sys.path so the src package imports during test collection

## Testing
- pytest -q --junitxml=logs/pytest.xml *(fails: existing changelog heading format expectation and simulated tomllib import failure)*

------
https://chatgpt.com/codex/tasks/task_e_68f89315fe248321aa26376087bca876