### PR TITLE
Harden OpenAI host suffix detection

### DIFF
--- a/src/orch/providers/openai.py
+++ b/src/orch/providers/openai.py
@@ -80,7 +80,7 @@ class OpenAICompatProvider(BaseProvider):
         def _matches_suffix(host: str, suffix: str) -> bool:
             return host == suffix or host.endswith(f".{suffix}")
 
-        is_openai_host = hostname.endswith("openai.com")
+        is_openai_host = _matches_suffix(hostname, "openai.com")
         is_azure_openai_host = any(
             _matches_suffix(hostname, suffix) for suffix in azure_compat_suffixes
         )

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -104,6 +104,18 @@ def test_openai_base_url_uses_chat_completions(monkeypatch: pytest.MonkeyPatch) 
     assert post_calls[0]["url"] == "https://api.openai.com/v1/chat/completions"
 
 
+def test_similar_domain_is_not_treated_as_openai_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    provider = make_provider("https://fooopenai.com")
+
+    post_calls, _ = run_chat(provider, monkeypatch)
+
+    assert post_calls
+    assert post_calls[0]["url"] == "https://fooopenai.com/chat/completions"
+
+
 def test_openai_preserves_existing_chat_completions_suffix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure the OpenAI host check only matches proper dot-delimited suffixes
- add a regression test covering similar-looking domains

## Testing
- pytest tests/test_providers_openai.py::test_similar_domain_is_not_treated_as_openai_host


------
https://chatgpt.com/codex/tasks/task_e_68feb589c3448321a9a69e02402de3f8