### PR TITLE
Sanitize server error messages

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -503,6 +503,17 @@ def _resolve_error_code(
     return error_type
 
 
+_GENERIC_INTERNAL_ERROR_MESSAGE = "internal server error"
+
+
+def _public_error_message(*, message: str, status_code: int, error_type: str) -> str:
+    _ = error_type
+    sanitized = message.strip()
+    if status_code >= 500:
+        return _GENERIC_INTERNAL_ERROR_MESSAGE
+    return sanitized or message
+
+
 def _make_error_body(
     *,
     status_code: int,
@@ -511,11 +522,14 @@ def _make_error_body(
     retry_after: int | None = None,
     code: "ErrorCode | str | None" = None,
 ) -> dict[str, Any]:
+    public_message = _public_error_message(
+        message=message, status_code=status_code, error_type=error_type
+    )
     resolved_code = _resolve_error_code(
         status_code=status_code, error_type=error_type, explicit=code
     )
     payload: dict[str, Any] = {
-        "message": message,
+        "message": public_message,
         "type": error_type,
         "code": resolved_code,
     }

--- a/tests/test_server_error_response.py
+++ b/tests/test_server_error_response.py
@@ -1,0 +1,20 @@
+from src.orch import server as orch_server
+
+
+def test_make_error_body_sanitizes_server_errors() -> None:
+    body = orch_server._make_error_body(
+        status_code=500,
+        message="ValueError: secret detail",
+        error_type="provider_server_error",
+    )
+    assert body["error"]["message"] == "internal server error"
+
+
+def test_make_error_body_preserves_client_errors() -> None:
+    message = "invalid request payload"
+    body = orch_server._make_error_body(
+        status_code=400,
+        message=message,
+        error_type="provider_error",
+    )
+    assert body["error"]["message"] == message


### PR DESCRIPTION
## Summary
- sanitize server error messages before returning them to clients
- add regression tests covering server and client error payloads

## Testing
- pytest tests/test_server_error_response.py

------
https://chatgpt.com/codex/tasks/task_e_68feb5e4a9308321b3754c524b51c696