### PR TITLE
Sanitize routing error responses

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -737,6 +737,7 @@ async def chat_completions(req: Request, body: ChatRequest) -> Response:
             route = plan_fn(task)
     except ValueError as exc:
         detail = str(exc) or "routing unavailable"
+        user_message = "routing unavailable"
         await _log_metrics({
             "req_id": req_id,
             "ts": time.time(),
@@ -754,7 +755,7 @@ async def chat_completions(req: Request, body: ChatRequest) -> Response:
         headers = _make_response_headers(req_id=req_id, provider=None, attempts=0)
         error_body = _make_error_body(
             status_code=400,
-            message=detail,
+            message=user_message,
             error_type="routing_error",
         )
         return JSONResponse(error_body, status_code=400, headers=headers)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -127,4 +127,4 @@ routes:
         message = payload["detail"]
     else:
         message = payload.get("error", {}).get("message", "")
-    assert "no route configured" in message
+    assert message == "routing unavailable"

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -2027,9 +2027,7 @@ def test_chat_missing_route_and_default_returns_400(route_test_config: Path) -> 
         },
     )
     assert response.status_code == 400
-    assert response.json()["error"]["message"] == (
-        "no route configured for task 'IDEATE' and no DEFAULT route defined in router configuration."
-    )
+    assert response.json()["error"]["message"] == "routing unavailable"
 
 
 def test_chat_missing_header_uses_default_task(route_test_config: Path) -> None:
@@ -2489,9 +2487,7 @@ routes:
         },
     )
     assert failure.status_code == 400
-    assert failure.json()["error"]["message"] == (
-        "no route configured for task 'DEFAULT' and no DEFAULT route defined in router configuration."
-    )
+    assert failure.json()["error"]["message"] == "routing unavailable"
 
 
 def test_chat_metrics_success_includes_req_id(


### PR DESCRIPTION
## Summary
- mask routing planner ValueError details in chat error responses while preserving metrics logging
- update routing-related tests to expect the generic user-facing message

## Testing
- pytest tests/test_server_routes.py::test_chat_missing_route_and_default_returns_400 tests/test_server_routes.py::test_chat_metrics_routing_error_includes_req_id tests/test_health.py::test_chat_missing_default_returns_400

------
https://chatgpt.com/codex/tasks/task_e_68feb5f42d308321bc24d4d8aa059c6a