### PR TITLE
Remove unused ProviderStreamChunk import from server streaming test

### DIFF
--- a/tests/test_server_streaming_events.py
+++ b/tests/test_server_streaming_events.py
@@ -7,14 +7,11 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, AsyncIterator, Callable
+from typing import Any, AsyncIterator, Callable
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
-
-if TYPE_CHECKING:
-    from src.orch.types import ProviderStreamChunk
 
 StreamFn = Callable[..., AsyncIterator[Any]]
 


### PR DESCRIPTION
## Summary
- remove the unused `ProviderStreamChunk` import guard from `tests/test_server_streaming_events.py`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68feb600fde08321a7beb710aee4a0a9