### PR TITLE
Potential fix for code scanning alert no. 6: First parameter of a method is not named 'self'

### DIFF
--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -579,10 +579,10 @@ def test_chat_records_planner_failure_on_guarded_errors(
             lease = object()
 
             class _Context:
-                async def __aenter__(self_inner) -> object:
+                async def __aenter__(self) -> object:
                     return lease
 
-                async def __aexit__(self_inner, exc_type, exc, tb) -> None:
+                async def __aexit__(self, exc_type, exc, tb) -> None:
                     return None
 
             return _Context()


### PR DESCRIPTION
Potential fix for [https://github.com/RNA4219/llm_orch/security/code-scanning/6](https://github.com/RNA4219/llm_orch/security/code-scanning/6)

To fix the problem, the `_Context` class's `__aexit__` method should have its first parameter renamed from `self_inner` to `self`. This aligns with PEP 8, Python conventions, and static analysis expectations. The edit should be made in the `tests/test_server_routes.py` file, in the definition of the `_Context` class inside the `FakeGuard.acquire` method, on the method `def __aexit__`. No imports or additional definitions are necessary; simply rename the first parameter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
