### PR TITLE
Sanitize multiline error messages in responses

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -511,7 +511,9 @@ def _public_error_message(*, message: str, status_code: int, error_type: str) ->
     sanitized = message.strip()
     if status_code >= 500:
         return _GENERIC_INTERNAL_ERROR_MESSAGE
-    return sanitized or message
+    if not sanitized:
+        return message
+    return sanitized.splitlines()[0]
 
 
 def _make_error_body(

--- a/tests/test_server_error_response.py
+++ b/tests/test_server_error_response.py
@@ -18,3 +18,12 @@ def test_make_error_body_preserves_client_errors() -> None:
         error_type="provider_error",
     )
     assert body["error"]["message"] == message
+
+
+def test_make_error_body_strips_stack_trace_from_client_errors() -> None:
+    body = orch_server._make_error_body(
+        status_code=400,
+        message="Traceback (most recent call last):\nValueError: bad",
+        error_type="provider_error",
+    )
+    assert body["error"]["message"] == "Traceback (most recent call last):"


### PR DESCRIPTION
## Summary
- trim multiline error messages returned in JSON responses to avoid leaking stack traces
- add regression test covering stack trace sanitization for client errors

## Testing
- pytest tests/test_server_error_response.py

------
https://chatgpt.com/codex/tasks/task_e_68feb98ae0288321ab7a698fbcb09b76