### PR TITLE
Potential fix for code scanning alert no. 4: First parameter of a method is not named 'self'

### DIFF
--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -408,10 +408,10 @@ def test_chat_uses_guard_estimates_and_records_usage(
             lease = self._lease
 
             class FakeGuardContext:
-                async def __aenter__(self_nonlocal) -> object:
+                async def __aenter__(self) -> object:
                     return lease
 
-                async def __aexit__(self_nonlocal, exc_type, exc, tb) -> None:
+                async def __aexit__(self, exc_type, exc, tb) -> None:
                     return None
 
             return FakeGuardContext()


### PR DESCRIPTION
Potential fix for [https://github.com/RNA4219/llm_orch/security/code-scanning/4](https://github.com/RNA4219/llm_orch/security/code-scanning/4)

To fix this problem, rename the `self_nonlocal` parameter to `self` in both the `__aenter__` and `__aexit__` methods of the inner class `FakeGuardContext` defined within the `acquire` method of the `FakeGuard` class. No logic or references inside these methods use the parameter name, so renaming just the argument suffices. This change is scoped to lines 411-415 inside `test_chat_uses_guard_estimates_and_records_usage` in `tests/test_server_routes.py`. No imports or external code require modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
