### PR TITLE
Potential fix for code scanning alert no. 3: First parameter of a method is not named 'self'

### DIFF
--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -408,10 +408,10 @@ def test_chat_uses_guard_estimates_and_records_usage(
             lease = self._lease
 
             class FakeGuardContext:
-                async def __aenter__(self_nonlocal) -> object:
+                async def __aenter__(self) -> object:
                     return lease
 
-                async def __aexit__(self_nonlocal, exc_type, exc, tb) -> None:
+                async def __aexit__(self, exc_type, exc, tb) -> None:
                     return None
 
             return FakeGuardContext()


### PR DESCRIPTION
Potential fix for [https://github.com/RNA4219/llm_orch/security/code-scanning/3](https://github.com/RNA4219/llm_orch/security/code-scanning/3)

The best way to fix the problem is to rename the first parameter of all instance methods to `self`, per Python conventions. Specifically, in the class `FakeGuardContext`, change the method signatures for `__aenter__` and `__aexit__` to use `self` instead of `self_nonlocal`. This should be done only for the indicated class and lines, keeping all internal logic and references unchanged except for the parameter name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
