### PR TITLE
Sanitize stack trace exposure in error responses

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -513,7 +513,10 @@ def _public_error_message(*, message: str, status_code: int, error_type: str) ->
         return _GENERIC_INTERNAL_ERROR_MESSAGE
     if not sanitized:
         return message
-    return sanitized.splitlines()[0]
+    first_line = sanitized.splitlines()[0]
+    if "traceback (most recent call last)" in first_line.casefold():
+        return _GENERIC_INTERNAL_ERROR_MESSAGE
+    return first_line
 
 
 def _make_error_body(

--- a/tests/test_server_error_response.py
+++ b/tests/test_server_error_response.py
@@ -26,4 +26,4 @@ def test_make_error_body_strips_stack_trace_from_client_errors() -> None:
         message="Traceback (most recent call last):\nValueError: bad",
         error_type="provider_error",
     )
-    assert body["error"]["message"] == "Traceback (most recent call last):"
+    assert body["error"]["message"] == "internal server error"


### PR DESCRIPTION
## Summary
- sanitize client error messages that contain stack traces to return a generic internal error message
- update the error response test to reflect the stack trace sanitization behavior

## Testing
- pytest tests/test_server_error_response.py

------
https://chatgpt.com/codex/tasks/task_e_68febbd00af08321b95ed5c234ed4bac