### PR TITLE
Disable service account token automount for llm-orch pod

### DIFF
--- a/charts/llm-orch/templates/llm-orch.yaml
+++ b/charts/llm-orch/templates/llm-orch.yaml
@@ -38,6 +38,7 @@ spec:
         app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
         app.kubernetes.io/component: "server"
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: {{ $name | quote }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
## Summary
- disable automount of the service account token for the llm-orch Deployment pod template to avoid unbound automounted tokens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69023bbc53348321a88a3c3201f2118e