### PR TITLE
Add default memory limit for Helm deployment

### DIFF
--- a/charts/llm-orch/templates/llm-orch.yaml
+++ b/charts/llm-orch/templates/llm-orch.yaml
@@ -55,6 +55,10 @@ spec:
 {{- with .Values.resources }}
           resources:
 {{ toYaml . | indent 12 }}
+{{- else }}
+          resources:
+            limits:
+              memory: "512Mi"
 {{- end }}
       volumes:
         - name: config


### PR DESCRIPTION
## Summary
- add a default memory limit for the llm-orch container when Helm resources are not provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69023bc723e883218bb43f23889b887b