### PR TITLE
Enforce default memory limit in llm-orch deployment

### DIFF
--- a/charts/llm-orch/templates/llm-orch.yaml
+++ b/charts/llm-orch/templates/llm-orch.yaml
@@ -53,14 +53,14 @@ spec:
             - name: config
               mountPath: /config
               readOnly: true
-{{- with .Values.resources }}
-          resources:
-{{ toYaml . | indent 12 }}
-{{- else }}
-          resources:
-            limits:
-              memory: "512Mi"
+{{- $resources := deepCopy (default (dict) .Values.resources) }}
+{{- if not (hasKey $resources "limits") }}
+{{- $_ := set $resources "limits" (dict "memory" "512Mi") }}
+{{- else if not (hasKey (index $resources "limits") "memory") }}
+{{- $_ := set (index $resources "limits") "memory" "512Mi" }}
 {{- end }}
+          resources:
+{{ toYaml $resources | indent 12 }}
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
## Summary
- ensure the llm-orch deployment container always sets a memory limit, defaulting to 512Mi when unspecified

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6902a6d95ae88321a9c03a89727c39ce