### PR TITLE
Ensure streaming cleanup re-raises cancellation

### DIFF
--- a/src/orch/server.py
+++ b/src/orch/server.py
@@ -1490,15 +1490,12 @@ async def _stream_chat_response(
             finally:
                 if not producer_task.done():
                     producer_task.cancel()
-                cancelled_error: asyncio.CancelledError | None = None
                 try:
                     await producer_task
-                except asyncio.CancelledError as exc:
-                    cancelled_error = exc
+                except asyncio.CancelledError:
+                    raise
                 except Exception:
                     pass
-                if cancelled_error is not None:
-                    raise cancelled_error
 
         response = StreamingResponse(event_source(), media_type="text/event-stream")
         response.headers.update(


### PR DESCRIPTION
## Summary
- ensure the streaming cleanup path re-raises `asyncio.CancelledError` after awaiting the producer task
- add a regression test covering cancellation while a subsequent chunk is pending

## Testing
- pytest tests/test_server_streaming_events.py::test_streaming_cleanup_reraises_cancelled_error_on_pending_chunk -q

------
https://chatgpt.com/codex/tasks/task_e_6902a9ff80c88321b73d1b0dde899c51